### PR TITLE
feat(prototype): allow for manual cloud run deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ On other platforms, see the [uv installation guide](https://docs.astral.sh/uv/ge
 
 ```bash
 # Clone the repository
-git clone https://github.com/m-lab/iqb.git
+git clone git@github.com:m-lab/iqb.git
 cd iqb
 
 # Sync all dependencies (creates .venv automatically)
@@ -85,5 +85,9 @@ uv run streamlit run Home.py
 ```
 
 See component-specific READMEs for more details:
+
+- [analysis/README.md](analysis/README.md) - Working with Jupyter notebooks
+
 - [library/README.md](library/README.md) - Working with the IQB library
+
 - [prototype/README.md](prototype/README.md) - Running the Streamlit app

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,64 @@
+# Cloud Build configuration for IQB prototype deployment
+# Used for manual deployment: gcloud builds submit --config=cloudbuild.yaml
+#
+# Based on M-Lab token-exchange pattern, adapted for mlab-sandbox environment
+
+substitutions:
+  # Default values, can be overridden when submitting the build
+  _REGION: us-central1
+  _REPOSITORY: cloud-run-source-deploy  # Same as github.com/sermpezis/m-lab-servers-dashboard
+  _SERVICE_NAME: iqb-prototype
+  _MEMORY: 1Gi
+  _CPU: "2"
+
+steps:
+  # 1. Build the Docker image from prototype/Dockerfile
+  - name: "gcr.io/cloud-builders/docker"
+    id: Build
+    args:
+      - "build"
+      - "-f"
+      - "prototype/Dockerfile"
+      - "-t"
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_SERVICE_NAME}:$BUILD_ID"
+      - "-t"
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_SERVICE_NAME}:latest"
+      - "."
+
+  # 2. Push the container image to Artifact Registry
+  # Note: This explicit push ensures the image exists before Deploy step runs.
+  # The BUILD_ID tag gets pushed again via images: section (harmless, just updates metadata).
+  - name: "gcr.io/cloud-builders/docker"
+    id: Push
+    args:
+      - "push"
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_SERVICE_NAME}:$BUILD_ID"
+    waitFor: ["Build"]
+
+  # 3. Deploy to Cloud Run
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: Deploy
+    entrypoint: gcloud
+    args:
+      - "run"
+      - "deploy"
+      - "${_SERVICE_NAME}"
+      - "--image"
+      - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_SERVICE_NAME}:$BUILD_ID"
+      - "--platform"
+      - "managed"
+      - "--region"
+      - "${_REGION}"
+      - "--allow-unauthenticated"
+      - "--memory=${_MEMORY}"
+      - "--cpu=${_CPU}"
+      - "--project=${PROJECT_ID}"
+    waitFor: ["Push"]
+
+# Push both tagged and latest images to registry
+images:
+  - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_SERVICE_NAME}:$BUILD_ID"
+  - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_SERVICE_NAME}:latest"
+
+# Build timeout (20 minutes)
+timeout: 1200s

--- a/prototype/README.md
+++ b/prototype/README.md
@@ -74,6 +74,42 @@ docker stop iqb-test
 docker rm iqb-test
 ```
 
+## Deploying to Cloud Run (Manual)
+
+Deploy to Google Cloud Run using Cloud Build:
+
+```bash
+# From the directory containing cloudbuild.yaml
+gcloud builds submit --config=cloudbuild.yaml --project=mlab-sandbox
+```
+
+This will:
+1. Build the Docker image from `prototype/Dockerfile`
+2. Push to Artifact Registry (`us-central1-docker.pkg.dev/mlab-sandbox/cloud-run-source-deploy`)
+3. Deploy to Cloud Run in `us-central1` region
+
+**Configuration:** See `cloudbuild.yaml` for deployment settings (memory, CPU, region).
+
+**Permissions required:**
+- `roles/editor` - Deploy and update services
+- `roles/run.admin` - Make new services public (only needed once per service)
+
+**Making the service public:**
+
+If deploying a new service or if you get 403 errors, an admin needs to run:
+
+```bash
+gcloud run services add-iam-policy-binding iqb-prototype \
+  --region=us-central1 \
+  --member="allUsers" \
+  --role="roles/run.invoker" \
+  --project=mlab-sandbox
+```
+
+This IAM policy persists across deployments, so it's only needed once.
+
+**Current deployment:** https://iqb-prototype-581276032543.us-central1.run.app/
+
 ## Dependencies
 
 The prototype depends on:


### PR DESCRIPTION
This diff adds `cloudbuild.yml` and explains how to manually deploy using cloud run.

We know this works because we successfully deployed the streamlit app.