### PR TITLE
fix(readme): correct snap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ management tools such as `pip`, `poetry`, etc.
 On Ubuntu:
 
 ```bash
-snap install astral-uv
+sudo snap install astral-uv --classic
 ```
 
 On macOS:


### PR DESCRIPTION
The command I originally provided is not the correct command to install `uv` on Ubuntu using snaps.