### PR TITLE
fix: start addressing `ruff check --fix .` issues

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -59,7 +59,8 @@ select = [
     "SIM", # flake8-simplify
 ]
 ignore = [
-    "E501",  # line too long (handled by formatter)
+    "E501",   # line too long (handled by formatter)
+    "SIM114", # combine if branches - prefer explicit branches for domain clarity
 ]
 
 [tool.ruff.lint.isort]

--- a/library/src/iqb/__init__.py
+++ b/library/src/iqb/__init__.py
@@ -4,8 +4,8 @@ This library provides methods for calculating the IQB score based on
 network measurement data, weight matrices, and quality thresholds.
 """
 
-from .iqb_score import IQB
 from .iqb_formula_config import IQB_CONFIG
+from .iqb_score import IQB
 
 __all__ = ["IQB", "IQB_CONFIG"]
 __version__ = "0.1.0"

--- a/library/src/iqb/iqb_score.py
+++ b/library/src/iqb/iqb_score.py
@@ -1,5 +1,6 @@
-from .iqb_formula_config import IQB_CONFIG
 from pprint import pprint
+
+from .iqb_formula_config import IQB_CONFIG
 
 
 class IQB:
@@ -49,7 +50,7 @@ class IQB:
         print()
 
         print("### Weights & Thresholds")
-        print(f"\tUse case\t \tNetwork requirement \tWeight \tThreshold min")
+        print("\tUse case\t \tNetwork requirement \tWeight \tThreshold min")
         for uc in IQB_CONFIG["use cases"]:
             for nr in IQB_CONFIG["use cases"][uc]["network requirements"]:
                 nr_w = IQB_CONFIG["use cases"][uc]["network requirements"][nr]["w"]

--- a/library/tests/iqb_score_test.py
+++ b/library/tests/iqb_score_test.py
@@ -1,6 +1,7 @@
 """Tests for the IQB score calculation module."""
 
 import pytest
+
 from iqb import IQB, IQB_CONFIG
 
 

--- a/prototype/Home.py
+++ b/prototype/Home.py
@@ -23,7 +23,7 @@ try:
     iqb = IQB()
     score = iqb.calculate_iqb_score()
 
-    st.success(f"✓ IQB Library loaded successfully")
+    st.success("✓ IQB Library loaded successfully")
     st.metric("Sample IQB Score", f"{score:.3f}")
 
     with st.expander("View IQB Configuration"):


### PR DESCRIPTION
This pull request starts addressing the issues surfacing when running:

```bash
uv run ruff check --fix .
```

I noticed that the current `ruff` configuration erred on the side of DRY but I would rather avoid that for domain clarity, so I disabled it.

In a subsequent diff, I'll address more issues that I preferred not to address now, lest we produce a large diff.