### PR TITLE
refactor!: use snake case for metric keys

### DIFF
--- a/library/src/iqb/config.py
+++ b/library/src/iqb/config.py
@@ -3,22 +3,22 @@ IQB_CONFIG = {
         "web browsing": {
             "w": 1,
             "network requirements": {
-                "download throughput": {
+                "download_throughput_mbps": {
                     "w": 3,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "upload throughput": {
+                "upload_throughput_mbps": {
                     "w": 2,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "latency": {
+                "latency_ms": {
                     "w": 4,
                     "threshold min": 100,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "packet loss": {
+                "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
@@ -28,22 +28,22 @@ IQB_CONFIG = {
         "video streaming": {
             "w": 1,
             "network requirements": {
-                "download throughput": {
+                "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 25,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "upload throughput": {
+                "upload_throughput_mbps": {
                     "w": 2,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "latency": {
+                "latency_ms": {
                     "w": 4,
                     "threshold min": 100,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "packet loss": {
+                "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
@@ -53,22 +53,22 @@ IQB_CONFIG = {
         "audio streaming": {
             "w": 1,
             "network requirements": {
-                "download throughput": {
+                "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "upload throughput": {
+                "upload_throughput_mbps": {
                     "w": 1,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "latency": {
+                "latency_ms": {
                     "w": 3,
                     "threshold min": 100,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "packet loss": {
+                "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
@@ -78,22 +78,22 @@ IQB_CONFIG = {
         "video conferencing": {
             "w": 1,
             "network requirements": {
-                "download throughput": {
+                "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "upload throughput": {
+                "upload_throughput_mbps": {
                     "w": 4,
                     "threshold min": 25,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "latency": {
+                "latency_ms": {
                     "w": 4,
                     "threshold min": 50,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "packet loss": {
+                "packet_loss": {
                     "w": 4,
                     "threshold min": 0.005,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
@@ -103,22 +103,22 @@ IQB_CONFIG = {
         "online backup": {
             "w": 1,
             "network requirements": {
-                "download throughput": {
+                "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "upload throughput": {
+                "upload_throughput_mbps": {
                     "w": 4,
                     "threshold min": 25,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "latency": {
+                "latency_ms": {
                     "w": 2,
                     "threshold min": 100,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "packet loss": {
+                "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
@@ -128,22 +128,22 @@ IQB_CONFIG = {
         "gaming": {
             "w": 1,
             "network requirements": {
-                "download throughput": {
+                "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "upload throughput": {
+                "upload_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "latency": {
+                "latency_ms": {
                     "w": 5,
                     "threshold min": 100,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
                 },
-                "packet loss": {
+                "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
                     "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},

--- a/library/src/iqb/score.py
+++ b/library/src/iqb/score.py
@@ -62,13 +62,13 @@ class IQB:
         - If the requirement is **throughput**, then the score is 1 if the given value is **larger** than the given threshold, and otherwise 0.
         - If the requirement is **latency or packet loss**, then the score is 1 if the given value is **smaller** than the given threshold, and otherwise 0.
         """
-        if network_requirement == "download throughput":
+        if network_requirement == "download_throughput_mbps":
             return 1 if value > threshold else 0
-        elif network_requirement == "upload throughput":
+        elif network_requirement == "upload_throughput_mbps":
             return 1 if value > threshold else 0
-        elif network_requirement == "latency":
+        elif network_requirement == "latency_ms":
             return 1 if value < threshold else 0
-        elif network_requirement == "packet loss":
+        elif network_requirement == "packet_loss":
             return 1 if value < threshold else 0
         else:
             raise ValueError(
@@ -83,10 +83,10 @@ class IQB:
             # TODO: TEMP data sample. To be updated by reading a file or variable or other resource.
             measurement_data = {
                 "m-lab": {
-                    "download throughput": 15,
-                    "upload throughput": 20,
-                    "latency": 75,
-                    "packet loss": 0.007,
+                    "download_throughput_mbps": 15,
+                    "upload_throughput_mbps": 20,
+                    "latency_ms": 75,
+                    "packet_loss": 0.007,
                 }
             }
         else:

--- a/library/tests/iqb/score_test.py
+++ b/library/tests/iqb/score_test.py
@@ -35,49 +35,49 @@ class TestBinaryRequirementScore:
     def test_download_throughput_above_threshold(self):
         """Test download throughput binary score when value exceeds threshold."""
         iqb = IQB()
-        score = iqb.calculate_binary_requirement_score("download throughput", 50, 25)
+        score = iqb.calculate_binary_requirement_score("download_throughput_mbps", 50, 25)
         assert score == 1
 
     def test_download_throughput_below_threshold(self):
         """Test download throughput binary score when value is below threshold."""
         iqb = IQB()
-        score = iqb.calculate_binary_requirement_score("download throughput", 20, 25)
+        score = iqb.calculate_binary_requirement_score("download_throughput_mbps", 20, 25)
         assert score == 0
 
     def test_upload_throughput_above_threshold(self):
         """Test upload throughput binary score when value exceeds threshold."""
         iqb = IQB()
-        score = iqb.calculate_binary_requirement_score("upload throughput", 30, 10)
+        score = iqb.calculate_binary_requirement_score("upload_throughput_mbps", 30, 10)
         assert score == 1
 
     def test_upload_throughput_below_threshold(self):
         """Test upload throughput binary score when value is below threshold."""
         iqb = IQB()
-        score = iqb.calculate_binary_requirement_score("upload throughput", 5, 10)
+        score = iqb.calculate_binary_requirement_score("upload_throughput_mbps", 5, 10)
         assert score == 0
 
     def test_latency_below_threshold(self):
         """Test latency binary score when value is below threshold (good)."""
         iqb = IQB()
-        score = iqb.calculate_binary_requirement_score("latency", 50, 100)
+        score = iqb.calculate_binary_requirement_score("latency_ms", 50, 100)
         assert score == 1
 
     def test_latency_above_threshold(self):
         """Test latency binary score when value exceeds threshold (bad)."""
         iqb = IQB()
-        score = iqb.calculate_binary_requirement_score("latency", 150, 100)
+        score = iqb.calculate_binary_requirement_score("latency_ms", 150, 100)
         assert score == 0
 
     def test_packet_loss_below_threshold(self):
         """Test packet loss binary score when value is below threshold (good)."""
         iqb = IQB()
-        score = iqb.calculate_binary_requirement_score("packet loss", 0.005, 0.01)
+        score = iqb.calculate_binary_requirement_score("packet_loss", 0.005, 0.01)
         assert score == 1
 
     def test_packet_loss_above_threshold(self):
         """Test packet loss binary score when value exceeds threshold (bad)."""
         iqb = IQB()
-        score = iqb.calculate_binary_requirement_score("packet loss", 0.02, 0.01)
+        score = iqb.calculate_binary_requirement_score("packet_loss", 0.02, 0.01)
         assert score == 0
 
     def test_invalid_network_requirement_raises_error(self):


### PR DESCRIPTION
The original format used strings with spaces. While this is ~okay with Python, it creates lots of friction when using the same structures in JavaScript.

In fact, when in JSON you have:

```JSON
{"download_speed_mbps": 11.4}
```

you can use it in JavaScript as:

```JavaScript
data.download_speed_mbps
```

whereas, when you have:

```JSON
{"download speed": 11.4}
```

you are forced to use:

```JavaScript
data["download speed"]
```

which is less convenient and less idiomatic.

Therefore, because IQB aims to be used from JavaScript, it seems much better to err on the side of idiomaticity.

BREAKING CHANGE: use snake case for IQB metrics keys.