### PR TITLE
refactor: assign proper name to calculator

### DIFF
--- a/library/src/iqb/__init__.py
+++ b/library/src/iqb/__init__.py
@@ -4,8 +4,11 @@ This library provides methods for calculating the IQB score based on
 network measurement data, weight matrices, and quality thresholds.
 """
 
+from .calculator import IQBCalculator
 from .config import IQB_CONFIG
-from .score import IQB
 
-__all__ = ["IQB", "IQB_CONFIG"]
+# Backward compatibility alias
+IQB = IQBCalculator
+
+__all__ = ["IQB", "IQBCalculator", "IQB_CONFIG"]
 __version__ = "0.1.0"

--- a/library/src/iqb/calculator.py
+++ b/library/src/iqb/calculator.py
@@ -1,16 +1,20 @@
+"""Module that implements calculating IQB scores."""
+
 from pprint import pprint
 
 from .config import IQB_CONFIG
 
 
-class IQB:
+class IQBCalculator:
+    """Component that calculates IQB scores."""
+
     def __init__(self, config=None, name=None):
         """
-        Initialize a new instance of IQB.
+        Initialize a new instance of IQBCalculator.
 
         Parameters:
             config (str): The file with the configuration of the IQB formula parameters. If "None" (default), it gets the parameters from the IQB_CONFIG dict.
-            name (str): [Optional] name for the IQB instance.
+            name (str): [Optional] name for the IQBCalculator instance.
         """
         self.set_config(config)
         self.name = name
@@ -52,7 +56,9 @@ class IQB:
         for uc in IQB_CONFIG["use cases"]:
             for nr in IQB_CONFIG["use cases"][uc]["network requirements"]:
                 nr_w = IQB_CONFIG["use cases"][uc]["network requirements"][nr]["w"]
-                nr_th = IQB_CONFIG["use cases"][uc]["network requirements"][nr]["threshold min"]
+                nr_th = IQB_CONFIG["use cases"][uc]["network requirements"][nr][
+                    "threshold min"
+                ]
                 print(f"\t{uc:20} \t{nr:20} \t{nr_w} \t{nr_th}")
         print()
 
@@ -107,15 +113,19 @@ class IQB:
             nr_weights = []
             for nr in self.config["use cases"][uc]["network requirements"]:
                 nr_w = self.config["use cases"][uc]["network requirements"][nr]["w"]
-                nr_th = self.config["use cases"][uc]["network requirements"][nr]["threshold min"]
+                nr_th = self.config["use cases"][uc]["network requirements"][nr][
+                    "threshold min"
+                ]
 
                 # TODO: TEMP method for calculating binary requirement scores. To be
                 # updated with weighted average of scores per dataset.
                 ds_s = []
-                for ds in self.config["use cases"][uc]["network requirements"][nr]["datasets"]:
-                    ds_w = self.config["use cases"][uc]["network requirements"][nr]["datasets"][ds][
-                        "w"
-                    ]
+                for ds in self.config["use cases"][uc]["network requirements"][nr][
+                    "datasets"
+                ]:
+                    ds_w = self.config["use cases"][uc]["network requirements"][nr][
+                        "datasets"
+                    ][ds]["w"]
                     if ds_w > 0:
                         # binary requirement score (dataset, network requirement)
                         brs = self.calculate_binary_requirement_score(

--- a/library/src/iqb/config.py
+++ b/library/src/iqb/config.py
@@ -1,3 +1,5 @@
+"""Module containing the default IQB configuration."""
+
 IQB_CONFIG = {
     "use cases": {
         "web browsing": {
@@ -6,22 +8,38 @@ IQB_CONFIG = {
                 "download_throughput_mbps": {
                     "w": 3,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "upload_throughput_mbps": {
                     "w": 2,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "latency_ms": {
                     "w": 4,
                     "threshold min": 100,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
             },
         },
@@ -31,22 +49,38 @@ IQB_CONFIG = {
                 "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 25,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "upload_throughput_mbps": {
                     "w": 2,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "latency_ms": {
                     "w": 4,
                     "threshold min": 100,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
             },
         },
@@ -56,22 +90,38 @@ IQB_CONFIG = {
                 "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "upload_throughput_mbps": {
                     "w": 1,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "latency_ms": {
                     "w": 3,
                     "threshold min": 100,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
             },
         },
@@ -81,22 +131,38 @@ IQB_CONFIG = {
                 "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "upload_throughput_mbps": {
                     "w": 4,
                     "threshold min": 25,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "latency_ms": {
                     "w": 4,
                     "threshold min": 50,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "packet_loss": {
                     "w": 4,
                     "threshold min": 0.005,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
             },
         },
@@ -106,22 +172,38 @@ IQB_CONFIG = {
                 "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "upload_throughput_mbps": {
                     "w": 4,
                     "threshold min": 25,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "latency_ms": {
                     "w": 2,
                     "threshold min": 100,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
             },
         },
@@ -131,22 +213,38 @@ IQB_CONFIG = {
                 "download_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "upload_throughput_mbps": {
                     "w": 4,
                     "threshold min": 10,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "latency_ms": {
                     "w": 5,
                     "threshold min": 100,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
                 "packet_loss": {
                     "w": 4,
                     "threshold min": 0.01,
-                    "datasets": {"m-lab": {"w": 1}, "cloudflare": {"w": 0}, "ookla": {"w": 0}},
+                    "datasets": {
+                        "m-lab": {"w": 1},
+                        "cloudflare": {"w": 0},
+                        "ookla": {"w": 0},
+                    },
                 },
             },
         },

--- a/library/tests/iqb/calculator_test.py
+++ b/library/tests/iqb/calculator_test.py
@@ -1,32 +1,32 @@
-"""Tests for the IQB score calculation module."""
+"""Tests for the IQBCalculator score calculation module."""
 
 import pytest
 
-from iqb import IQB, IQB_CONFIG
+from iqb import IQBCalculator, IQB_CONFIG
 
 
-class TestIQBInitialization:
-    """Tests for IQB class initialization."""
+class TestIQBCalculatorInitialization:
+    """Tests for IQBCalculator class initialization."""
 
     def test_init_with_name(self):
-        """Test that IQB can be instantiated with a name."""
-        iqb = IQB(name="test1")
+        """Test that IQBCalculator can be instantiated with a name."""
+        iqb = IQBCalculator(name="test1")
         assert iqb.name == "test1"
 
     def test_init_without_name(self):
-        """Test that IQB can be instantiated without a name."""
-        iqb = IQB()
+        """Test that IQBCalculator can be instantiated without a name."""
+        iqb = IQBCalculator()
         assert iqb.name is None
 
     def test_init_uses_default_config(self):
-        """Test that IQB uses default config when none provided."""
-        iqb = IQB()
+        """Test that IQBCalculator uses default config when none provided."""
+        iqb = IQBCalculator()
         assert iqb.config == IQB_CONFIG
 
     def test_init_with_invalid_config_raises_error(self):
         """Test that providing a non-existent config file raises NotImplementedError."""
         with pytest.raises(NotImplementedError):
-            IQB(config="non_existing_file.json")
+            IQBCalculator(config="non_existing_file.json")
 
 
 class TestBinaryRequirementScore:
@@ -34,65 +34,65 @@ class TestBinaryRequirementScore:
 
     def test_download_throughput_above_threshold(self):
         """Test download throughput binary score when value exceeds threshold."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         score = iqb.calculate_binary_requirement_score("download_throughput_mbps", 50, 25)
         assert score == 1
 
     def test_download_throughput_below_threshold(self):
         """Test download throughput binary score when value is below threshold."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         score = iqb.calculate_binary_requirement_score("download_throughput_mbps", 20, 25)
         assert score == 0
 
     def test_upload_throughput_above_threshold(self):
         """Test upload throughput binary score when value exceeds threshold."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         score = iqb.calculate_binary_requirement_score("upload_throughput_mbps", 30, 10)
         assert score == 1
 
     def test_upload_throughput_below_threshold(self):
         """Test upload throughput binary score when value is below threshold."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         score = iqb.calculate_binary_requirement_score("upload_throughput_mbps", 5, 10)
         assert score == 0
 
     def test_latency_below_threshold(self):
         """Test latency binary score when value is below threshold (good)."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         score = iqb.calculate_binary_requirement_score("latency_ms", 50, 100)
         assert score == 1
 
     def test_latency_above_threshold(self):
         """Test latency binary score when value exceeds threshold (bad)."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         score = iqb.calculate_binary_requirement_score("latency_ms", 150, 100)
         assert score == 0
 
     def test_packet_loss_below_threshold(self):
         """Test packet loss binary score when value is below threshold (good)."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         score = iqb.calculate_binary_requirement_score("packet_loss", 0.005, 0.01)
         assert score == 1
 
     def test_packet_loss_above_threshold(self):
         """Test packet loss binary score when value exceeds threshold (bad)."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         score = iqb.calculate_binary_requirement_score("packet_loss", 0.02, 0.01)
         assert score == 0
 
     def test_invalid_network_requirement_raises_error(self):
         """Test that an invalid network requirement raises ValueError."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         with pytest.raises(ValueError, match="not implemented for the network_requirement"):
             iqb.calculate_binary_requirement_score("invalid_requirement", 50, 25)
 
 
-class TestIQBScoreCalculation:
-    """Tests for IQB score calculation."""
+class TestIQBCalculatorScoreCalculation:
+    """Tests for IQBCalculator score calculation."""
 
     def test_calculate_iqb_score_default_data(self):
-        """Test that IQB score can be calculated with default data."""
-        iqb = IQB(name="test1")
+        """Test that IQBCalculator score can be calculated with default data."""
+        iqb = IQBCalculator(name="test1")
         score = iqb.calculate_iqb_score()
         # The score should be a float between 0 and 1
         assert isinstance(score, (int, float))
@@ -100,44 +100,44 @@ class TestIQBScoreCalculation:
 
     def test_calculate_iqb_score_with_custom_data_raises_error(self):
         """Test that passing custom data raises NotImplementedError."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         with pytest.raises(NotImplementedError):
             iqb.calculate_iqb_score(data={})
 
     def test_calculate_iqb_score_print_details(self):
-        """Test that IQB score calculation works with print_details=True."""
-        iqb = IQB()
+        """Test that IQBCalculator score calculation works with print_details=True."""
+        iqb = IQBCalculator()
         score = iqb.calculate_iqb_score(print_details=True)
         assert isinstance(score, (int, float))
         assert 0 <= score <= 1
 
     def test_calculate_iqb_score_consistency(self):
-        """Test that IQB score calculation is consistent across calls."""
-        iqb = IQB()
+        """Test that IQBCalculator score calculation is consistent across calls."""
+        iqb = IQBCalculator()
         score1 = iqb.calculate_iqb_score()
         score2 = iqb.calculate_iqb_score()
         assert score1 == score2
 
 
-class TestIQBConfig:
-    """Tests for IQB configuration."""
+class TestIQBCalculatorConfig:
+    """Tests for IQBCalculator configuration."""
 
     def test_config_has_use_cases(self):
         """Test that config contains use cases."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         assert "use cases" in iqb.config
         assert len(iqb.config["use cases"]) > 0
 
     def test_config_use_cases_have_network_requirements(self):
         """Test that each use case has network requirements."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         for use_case in iqb.config["use cases"].values():
             assert "network requirements" in use_case
             assert len(use_case["network requirements"]) > 0
 
     def test_config_network_requirements_have_weights(self):
         """Test that each network requirement has weights."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         for use_case in iqb.config["use cases"].values():
             for nr in use_case["network requirements"].values():
                 assert "w" in nr
@@ -145,18 +145,18 @@ class TestIQBConfig:
 
     def test_config_network_requirements_have_thresholds(self):
         """Test that each network requirement has thresholds."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         for use_case in iqb.config["use cases"].values():
             for nr in use_case["network requirements"].values():
                 assert "threshold min" in nr
 
 
-class TestIQBMethods:
-    """Tests for IQB utility methods."""
+class TestIQBCalculatorMethods:
+    """Tests for IQBCalculator utility methods."""
 
     def test_print_config_runs_without_error(self, capsys):
         """Test that print_config method runs without errors."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         iqb.print_config()
         captured = capsys.readouterr()
         assert "### IQB formula weights and thresholds" in captured.out
@@ -166,12 +166,12 @@ class TestIQBMethods:
 
     def test_set_config_with_none(self):
         """Test that set_config works with None."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         iqb.set_config(None)
         assert iqb.config == IQB_CONFIG
 
     def test_set_config_with_file_raises_error(self):
         """Test that set_config raises error for file paths."""
-        iqb = IQB()
+        iqb = IQBCalculator()
         with pytest.raises(NotImplementedError):
             iqb.set_config("some_file.json")


### PR DESCRIPTION
The proper component name seems to be "calculator". The following description of the component seems reasonable and reads well:

> The IQBCalculator component calculates the IQB score.

Keep a backward compatibility alias `IQB` until we introduce a facade to unify all IQB operations.

Refactor files and add additional docstrings.