### PR TITLE
fix(data): use `measurement-lab` project

### DIFF
--- a/data/run_query.py
+++ b/data/run_query.py
@@ -122,10 +122,7 @@ def run_bq_query(
 
 
 def main():
-    # TODO(bassosimone): Should we use 'measurement-lab' as the project ID instead?
-    # The web console (https://console.cloud.google.com/bigquery?project=measurement-lab)
-    # uses measurement-lab as the project, so I am a bit unsure about what to use here.
-    DEFAULT_PROJECT_ID = "mlab-sandbox"
+    DEFAULT_PROJECT_ID = "measurement-lab"
 
     parser = argparse.ArgumentParser(
         description="Execute BigQuery query template and save results"


### PR DESCRIPTION
The [documentation](https://www.measurementlab.net/data/docs/bq/quickstart/) explicitly mentions `measurement-lab` as the project.

I was previously using the `mlab-sandbox` project instead. And there was a TODO issue assigned to me to sort this out.

FWIW, re-running the pipeline *after* changing the project does not yield different results in terms of number of tests per country. Therefore, I suspect the impact of this change is epsilon. Yet, let us follow the documented approach.

As noted previously, yet, BigQuery being distributed and quantiles being approximate cause lots of churn in the quantile values when re-running queries, so I am not committing the changes to avoid creating unnecessary increases in the overall size of this repository.