### PR TITLE
refactor(cache): factor data_dir_or_default func

### DIFF
--- a/library/src/iqb/cache.py
+++ b/library/src/iqb/cache.py
@@ -26,6 +26,14 @@ from datetime import datetime
 from pathlib import Path
 
 
+def data_dir_or_default(data_dir: str | Path | None) -> Path:
+    """
+    Return data_dir as a Path if not empty. Otherwise return the
+    default value for the data_dir (i.e., `./.iqb` like git).
+    """
+    return Path.cwd() / ".iqb" if data_dir is None else Path(data_dir)
+
+
 class IQBCache:
     """Component for fetching IQB measurement data from cache."""
 
@@ -37,10 +45,7 @@ class IQBCache:
             data_dir: Path to directory containing cached data files.
                 If None, defaults to .iqb/ in current working directory.
         """
-        if data_dir is None:
-            self.data_dir = Path.cwd() / ".iqb"
-        else:
-            self.data_dir = Path(data_dir)
+        self.data_dir = data_dir_or_default(data_dir)
 
     def get_data(
         self,

--- a/library/tests/iqb/cache_test.py
+++ b/library/tests/iqb/cache_test.py
@@ -1,10 +1,34 @@
 """Tests for the IQBCache data fetching module."""
 
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
 from iqb import IQBCache
+from iqb.cache import data_dir_or_default
+
+
+class TestDataDirOrDefault:
+    """Test pure functions without external dependencies."""
+
+    def test_data_dir_or_default_with_none(self):
+        """Test default behavior when data_dir is None."""
+        result = data_dir_or_default(None)
+        expected = Path.cwd() / ".iqb"
+        assert result == expected
+
+    def test_data_dir_or_default_with_string(self, tmp_path):
+        """Test conversion of string path."""
+        test_path = str(tmp_path / "test")
+        result = data_dir_or_default(test_path)
+        assert result == Path(test_path)
+
+    def test_data_dir_or_default_with_path(self, tmp_path):
+        """Test pass-through of Path object."""
+        input_path = tmp_path / "test"
+        result = data_dir_or_default(input_path)
+        assert result == input_path
 
 
 class TestIQBCacheInitialization:


### PR DESCRIPTION
This diff refactors the logic to get a data directory or a default data directory into a separate function.

While there, add minimal tests for this new function.