### PR TITLE
refactor(iqb/cache): use cache/v1 instead of cache/v0

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pyarrow>=14.0.0",
     "pandas>=2.0.0",
     "db-dtypes>=1.0.0",
+    "python-dateutil>=2.9.0.post0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1363,6 +1363,7 @@ dependencies = [
     { name = "google-cloud-bigquery-storage" },
     { name = "pandas" },
     { name = "pyarrow" },
+    { name = "python-dateutil" },
 ]
 
 [package.dev-dependencies]
@@ -1379,6 +1380,7 @@ requires-dist = [
     { name = "google-cloud-bigquery-storage", specifier = ">=2.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Reimplement the same functionality we had before (i.e., reading country data for m-lab only) using cache/v1.

This means that, from now on, we read Parquet files rather than JSON files.