### PR TITLE
feat(data): use GitHub releases as interim cache

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -47,6 +47,50 @@ Raw query results stored efficiently for flexible analysis:
 **Migration**: The [../library](../library) `IQBCache` uses v1. We are keeping v0 data
 around as golden files, for backward compatibility, and casual use.
 
+## GitHub Cache Synchronization (Interim Solution)
+
+**IMPORTANT**: This is a throwaway interim solution that will be replaced by GCS.
+
+Since the v1 Parquet files can be large (~1-60 MiB) and we have BigQuery quota
+constraints, we use GitHub releases to distribute pre-generated cache files.
+
+### For Data Scientists (Manual Workflow)
+
+Sync cached files from GitHub before analysis:
+
+```bash
+cd data/
+./ghcache.py sync
+```
+
+This downloads any missing cache files listed in `ghcache.json` and verifies SHA256.
+
+### For Pipeline Users (Automatic)
+
+The `generate_data.py` script automatically syncs cached files before running queries,
+so you don't need to run `ghcache.py` manually.
+
+### For Maintainers (Publishing New Cache)
+
+When you generate new cache files locally:
+
+```bash
+cd data/
+./ghcache.py scan
+```
+
+This:
+1. Scans `cache/v1/` for git-ignored files
+2. Computes SHA256 hashes
+3. Copies files to `data/` with mangled names (ready for upload)
+4. Updates `ghcache.json` manifest
+
+Then manually:
+1. Upload mangled files to GitHub release (e.g., v0.1.0)
+2. Commit updated `ghcache.json` to repository
+
+**Note**: This system assumes Unix paths and won't work on Windows.
+
 ## How This Data Was Generated
 
 ### BigQuery Queries
@@ -159,7 +203,6 @@ for details.
 ## Future Improvements (Phase 2+)
 
 - Finer geographic resolution (cities, provinces, ASNs) - IN PROGRESS
-- Remote storage for `cache/v1` data (GitHub releases)
+- Replace GitHub releases with GCS buckets for cache distribution
 - Additional datasets (Ookla, Cloudflare)
 - Finer time granularity (daily, weekly)
-- Remote storage for `cache/v1` data (GCS buckets)

--- a/data/generate_data.py
+++ b/data/generate_data.py
@@ -3,6 +3,7 @@
 Orchestrate the data generation pipeline for IQB static data.
 
 This script:
+0. Syncs cached files from GitHub (if available)
 1. Runs BigQuery queries for downloads and uploads for multiple time periods
 2. Merges the results into per-country JSON files
 """
@@ -131,6 +132,16 @@ def main():
 
     print("IQB Data Generation Pipeline")
     print("=" * 60)
+
+    # Stage 0: Sync cached files from GitHub (if manifest exists)
+    ghcache_script = data_dir / "ghcache.py"
+    if ghcache_script.exists():
+        run_command(
+            ["python3", str(ghcache_script), "sync"],
+            "Stage 0: Syncing cached files from GitHub",
+        )
+    else:
+        print("\nNote: ghcache.py not found, skipping cache sync")
 
     # Generate data for October 2024
     generate_for_period(data_dir, "2024-10-01", "2024-11-01", "2024_10")

--- a/data/ghcache.json
+++ b/data/ghcache.json
@@ -1,0 +1,29 @@
+{
+  "files": {
+    "cache/v1/20241001T000000Z/20241101T000000Z/downloads_by_country_city_asn/data.parquet": {
+      "sha256": "92162c968ff13bf975816f0e01f05d36c448ab78c7933daf5a4dda4117ed6fae",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/92162c968ff1__cache__v1__20241001T000000Z__20241101T000000Z__downloads_by_country_city_asn__data.parquet"
+    },
+    "cache/v1/20241001T000000Z/20241101T000000Z/downloads_by_country_city_asn/stats.json": {
+      "sha256": "51053e78cee26caed62d4146513592ff619de2df812e68ce3960a91c50a023e4",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/51053e78cee2__cache__v1__20241001T000000Z__20241101T000000Z__downloads_by_country_city_asn__stats.json"
+    },
+    "cache/v1/20241001T000000Z/20241101T000000Z/uploads_by_country_city_asn/data.parquet": {
+      "sha256": "f86833aee1439116e8fc5194dcf76c0cbc6cc9f202b664826577392b2bbfa581",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/f86833aee143__cache__v1__20241001T000000Z__20241101T000000Z__uploads_by_country_city_asn__data.parquet"
+    },
+    "cache/v1/20241001T000000Z/20241101T000000Z/uploads_by_country_city_asn/stats.json": {
+      "sha256": "5bf42dc256d2602a9228c018146c2ad0aa38ec69e9553e89afd854487eee57dd",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/5bf42dc256d2__cache__v1__20241001T000000Z__20241101T000000Z__uploads_by_country_city_asn__stats.json"
+    },
+    "cache/v1/20251001T000000Z/20251101T000000Z/downloads_by_country_city_asn/data.parquet": {
+      "sha256": "31f70c002e82044662c8afa3b90dd6d970cb46edede5196d54864e104c87fccb",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/31f70c002e82__cache__v1__20251001T000000Z__20251101T000000Z__downloads_by_country_city_asn__data.parquet"
+    },
+    "cache/v1/20251001T000000Z/20251101T000000Z/downloads_by_country_city_asn/stats.json": {
+      "sha256": "8498d95733361e6e19dd10c613129917abadf7dae933c7b8684da203f8258802",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/8498d9573336__cache__v1__20251001T000000Z__20251101T000000Z__downloads_by_country_city_asn__stats.json"
+    }
+  },
+  "v": 0
+}

--- a/data/ghcache.py
+++ b/data/ghcache.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+
+"""
+GitHub cache synchronization tool for IQB data files.
+
+**INTERIM SOLUTION**: This is a throwaway script for the initial phase of the
+project. It will eventually be replaced by a proper GCS-based solution. The
+script assumes Unix file paths and will not work on Windows.
+
+This tool manages caching of large parquet/JSON files using GitHub releases
+as a distribution mechanism, with local SHA256 verification.
+
+Subcommands:
+  scan - Scan local files and prepare them for upload to GitHub release
+  sync - Download files from GitHub release based on manifest
+
+The 'scan' command copies files to the current directory with mangled names,
+ready for manual upload to GitHub releases.
+
+Manifest format (ghcache.json):
+{
+  "v": 0,
+  "files": {
+    "cache/v1/.../data.parquet": {
+      "sha256": "3a421c62179a...",
+      "url": "https://github.com/.../3a421c62179a__cache__v1__...parquet"
+    }
+  }
+}
+
+File path format: cache/v1/{start_ts}/{end_ts}/{name}/data.parquet
+Mangled format: {sha256[:12]}__cache__v1__{start_ts}__{end_ts}__{name}__data.parquet
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+
+MANIFEST_FILE = "ghcache.json"
+CACHE_DIR = Path("cache/v1")
+SHA256_PREFIX_LENGTH = 12
+
+
+def compute_sha256(file_path: Path) -> str:
+    """Compute SHA256 hash of a file."""
+    sha256 = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        while chunk := f.read(8192):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def validate_cache_path(path: str) -> bool:
+    """
+    Validate that a path follows the cache/v1 format.
+
+    Valid format:
+      cache/v1/{rfc3339_timestamp}/{rfc3339_timestamp}/{name}/{file}
+
+    Where:
+      - Component 1: "cache"
+      - Component 2: "v1"
+      - Component 3: RFC3339 timestamp (e.g., 20241001T000000Z)
+      - Component 4: RFC3339 timestamp
+      - Component 5: lowercase letters and underscores [a-z_]+
+      - Component 6: "data.parquet" or "stats.json"
+    """
+    parts = path.split("/")
+    if len(parts) != 6:
+        return False
+
+    # Component 1: cache
+    if parts[0] != "cache":
+        return False
+
+    # Component 2: v1
+    if parts[1] != "v1":
+        return False
+
+    # Components 3-4: RFC3339 timestamps (YYYYMMDDTHHMMSSZ format)
+    rfc3339_pattern = re.compile(r"^\d{8}T\d{6}Z$")
+    if not rfc3339_pattern.match(parts[2]):
+        return False
+    if not rfc3339_pattern.match(parts[3]):
+        return False
+
+    # Component 5: lowercase letters and underscores
+    name_pattern = re.compile(r"^[a-z_]+$")
+    if not name_pattern.match(parts[4]):
+        return False
+
+    # Component 6: data.parquet or stats.json
+    if parts[5] not in ("data.parquet", "stats.json"):
+        return False
+
+    return True
+
+
+def mangle_path(local_path: str, sha256: str) -> str:
+    """
+    Convert local path to mangled GitHub release filename.
+
+    Example:
+      Input:  cache/v1/20241001T000000Z/20241101T000000Z/downloads_by_country/data.parquet
+      SHA256: 3a421c62179a...
+      Output: 3a421c62179a__cache__v1__20241001T000000Z__20241101T000000Z__downloads_by_country__data.parquet
+    """
+    sha_prefix = sha256[:SHA256_PREFIX_LENGTH]
+    mangled = local_path.replace("/", "__")
+    return f"{sha_prefix}__{mangled}"
+
+
+def demangle_path(mangled_name: str) -> str | None:
+    """
+    Convert mangled filename back to local path.
+
+    Returns None if the format is invalid.
+
+    Example:
+      Input:  3a421c62179a__cache__v1__20241001T000000Z__20241101T000000Z__downloads_by_country__data.parquet
+      Output: cache/v1/20241001T000000Z/20241101T000000Z/downloads_by_country/data.parquet
+    """
+    # Expected format: {12-char-hex}__cache__v1__...
+    if not re.match(r"^[a-f0-9]{12}__", mangled_name):
+        return None
+
+    # Remove SHA256 prefix
+    parts = mangled_name.split("__", 1)
+    if len(parts) != 2:
+        return None
+
+    # Convert __ back to /
+    local_path = parts[1].replace("__", "/")
+
+    # Validate the demangled path
+    if not validate_cache_path(local_path):
+        return None
+
+    return local_path
+
+
+def load_manifest() -> dict:
+    """Load manifest from ghcache.json, or return empty manifest if not found."""
+    manifest_path = Path(MANIFEST_FILE)
+    if not manifest_path.exists():
+        return {"v": 0, "files": {}}
+
+    with open(manifest_path, "r") as f:
+        return json.load(f)
+
+
+def save_manifest(manifest: dict) -> None:
+    """Save manifest to ghcache.json."""
+    with open(MANIFEST_FILE, "w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")  # Trailing newline
+
+
+def is_git_ignored(file_path: Path) -> bool:
+    """Check if a file is ignored by git."""
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", str(file_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Exit code 0 means the file is ignored
+        return result.returncode == 0
+    except Exception:
+        # If git isn't available or other error, assume not ignored
+        return False
+
+
+def download_file(url: str, dest_path: Path) -> None:
+    """Download a file from URL to destination path."""
+    print(f"  Downloading from {url}")
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with urllib.request.urlopen(url) as response:
+        with open(dest_path, "wb") as f:
+            while chunk := response.read(8192):
+                f.write(chunk)
+
+
+def cmd_sync(args) -> int:
+    """
+    Sync command: Download files from GitHub based on manifest.
+
+    For each entry in the manifest:
+    1. Check if local file exists
+    2. If exists, verify SHA256
+    3. If missing or SHA256 mismatch, download from URL
+    """
+    manifest = load_manifest()
+
+    if not manifest.get("files"):
+        print("No files in manifest.")
+        return 0
+
+    print(f"Checking {len(manifest['files'])} files from manifest...")
+
+    for local_path, file_info in manifest["files"].items():
+        expected_sha256 = file_info["sha256"]
+        url = file_info["url"]
+
+        file_path = Path(local_path)
+
+        # Check if file exists
+        if not file_path.exists():
+            print(f"Missing: {local_path}")
+            download_file(url, file_path)
+            continue
+
+        # Verify SHA256
+        actual_sha256 = compute_sha256(file_path)
+        if actual_sha256 != expected_sha256:
+            print(f"SHA256 mismatch: {local_path}")
+            print(f"  Expected: {expected_sha256}")
+            print(f"  Actual:   {actual_sha256}")
+            print(f"  Re-downloading...")
+            download_file(url, file_path)
+        else:
+            print(f"OK: {local_path}")
+
+    return 0
+
+
+def cmd_scan(args) -> int:
+    """
+    Scan command: Scan local files and prepare for upload.
+
+    1. Load or create manifest
+    2. Scan cache/v1 for git-ignored files
+    3. For new or changed files:
+       - Compute SHA256
+       - Create mangled filename
+       - Copy to current directory (ready for manual upload)
+       - Update manifest
+    4. Save manifest
+    """
+    manifest = load_manifest()
+    files_dict = manifest.setdefault("files", {})
+
+    if not CACHE_DIR.exists():
+        print(f"Cache directory {CACHE_DIR} does not exist.")
+        return 1
+
+    print(f"Scanning {CACHE_DIR} for git-ignored files...")
+
+    # Find all files under cache/v1
+    all_files = list(CACHE_DIR.rglob("*"))
+    cache_files = [f for f in all_files if f.is_file()]
+
+    # Filter to only git-ignored files
+    ignored_files = [f for f in cache_files if is_git_ignored(f)]
+
+    if not ignored_files:
+        print("No git-ignored files found.")
+        return 0
+
+    print(f"Found {len(ignored_files)} git-ignored files.")
+
+    files_to_upload = []
+
+    for file_path in ignored_files:
+        # Convert to relative path string (already relative since we chdir'd)
+        rel_path = str(file_path)
+
+        # Validate path format
+        if not validate_cache_path(rel_path):
+            print(f"Skipping invalid path format: {rel_path}")
+            continue
+
+        # Compute SHA256
+        sha256 = compute_sha256(file_path)
+
+        # Check if file is already in manifest with same SHA256
+        existing_entry = files_dict.get(rel_path)
+        if existing_entry and existing_entry["sha256"] == sha256:
+            print(f"Already in manifest: {rel_path}")
+            continue
+
+        # File is new or changed
+        print(f"New/changed: {rel_path}")
+        print(f"  SHA256: {sha256}")
+
+        # Create mangled filename
+        mangled_name = mangle_path(rel_path, sha256)
+        print(f"  Mangled: {mangled_name}")
+
+        # Copy to current directory with mangled name (for manual upload)
+        dest_path = Path(mangled_name)
+        shutil.copy2(file_path, dest_path)
+        print(f"  Copied to ./{mangled_name} (ready for upload)")
+
+        # Prepare manifest entry (URL will need to be filled in manually or via script)
+        # For now, use placeholder URL
+        url_placeholder = f"https://github.com/m-lab/iqb/releases/download/v0.1.0/{mangled_name}"
+
+        files_dict[rel_path] = {"sha256": sha256, "url": url_placeholder}
+        files_to_upload.append(mangled_name)
+
+    # Save updated manifest
+    save_manifest(manifest)
+    print(f"\nManifest updated: {MANIFEST_FILE}")
+
+    if files_to_upload:
+        print(f"\nFiles ready for upload ({len(files_to_upload)}):")
+        for f in files_to_upload:
+            print(f"  {f}")
+        print("\nNext steps:")
+        print("1. Upload mangled files to GitHub release v0.1.0")
+        print("2. Update URLs in ghcache.json if needed")
+        print("3. Commit updated ghcache.json to repository")
+
+    return 0
+
+
+def main() -> int:
+    # Reject Windows - this script assumes Unix file paths
+    if platform.system() == "Windows":
+        print("ERROR: This script does not support Windows.", file=sys.stderr)
+        print("Reason: Assumes Unix file path conventions.", file=sys.stderr)
+        print("Note: This is an interim solution that will be replaced by GCS.", file=sys.stderr)
+        return 1
+
+    # Change to script's directory (./data) so all paths are relative to it
+    script_dir = Path(__file__).resolve().parent
+    os.chdir(script_dir)
+
+    parser = argparse.ArgumentParser(
+        description="GitHub cache synchronization tool for IQB data files (interim solution)"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Subcommand to run")
+
+    # Scan subcommand
+    parser_scan = subparsers.add_parser(
+        "scan", help="Scan local files and prepare for upload"
+    )
+
+    # Sync subcommand
+    parser_sync = subparsers.add_parser(
+        "sync", help="Download files from GitHub based on manifest"
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "scan":
+        return cmd_scan(args)
+    elif args.command == "sync":
+        return cmd_sync(args)
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/run_query.py
+++ b/data/run_query.py
@@ -101,13 +101,17 @@ def run_bq_query(
         end_date=end_date,
         fetch_if_missing=True,
     )
-    print(f"✓ Cache entry: {entry.data_path.parent.name}", file=sys.stderr)
-    print(f"  Data: {entry.data_path}", file=sys.stderr)
-    print(f"  Stats: {entry.stats_path}", file=sys.stderr)
+    data_path = entry.data_path()
+    assert data_path is not None
+    stats_path = entry.stats_path()
+    assert stats_path is not None
+    print(f"✓ Cache entry: {data_path.parent.name}", file=sys.stderr)
+    print(f"  Data: {data_path}", file=sys.stderr)
+    print(f"  Stats: {stats_path}", file=sys.stderr)
 
     # Step 2: Convert the parquet file to JSON
     print("Converting parquet to JSON...", file=sys.stderr)
-    table = pq.read_table(entry.data_path)
+    table = pq.read_table(data_path)
     records = table.to_pylist()
 
     # Check if query returned no results


### PR DESCRIPTION
Add `./data/ghcache.py` that allows to ~easily (and manually) publish assets inside the `v0.1` GitHub release, register their path and URL and retriee them at a later time.

Add `./data/ghcache.json` that records the assets.

We only include as assets the gitignored files in `./data/cache/v1`.

Update the `./data/README.md` file to mention this interim feature and the `./data/generate_data.py` script to invoke `./data/ghcache.py` before running, to sync assets from GitHub.

While there, fix issue with `./data/run_query.py` where we did not migrate the script after changing the `.../iqb/cache.py` API (it seems that unit tests are useful in Python after all! :-).