### PR TITLE
refactor(PipelineCacheEntry)!: return `Path` not `Path | None`

### DIFF
--- a/data/ghcache.py
+++ b/data/ghcache.py
@@ -304,7 +304,9 @@ def cmd_scan(args) -> int:
 
         # Prepare manifest entry (URL will need to be filled in manually or via script)
         # For now, use placeholder URL
-        url_placeholder = f"https://github.com/m-lab/iqb/releases/download/v0.1.0/{mangled_name}"
+        url_placeholder = (
+            f"https://github.com/m-lab/iqb/releases/download/v0.1.0/{mangled_name}"
+        )
 
         files_dict[rel_path] = {"sha256": sha256, "url": url_placeholder}
         files_to_upload.append(mangled_name)
@@ -330,7 +332,10 @@ def main() -> int:
     if platform.system() == "Windows":
         print("ERROR: This script does not support Windows.", file=sys.stderr)
         print("Reason: Assumes Unix file path conventions.", file=sys.stderr)
-        print("Note: This is an interim solution that will be replaced by GCS.", file=sys.stderr)
+        print(
+            "Note: This is an interim solution that will be replaced by GCS.",
+            file=sys.stderr,
+        )
         return 1
 
     # Change to script's directory (./data) so all paths are relative to it

--- a/data/run_query.py
+++ b/data/run_query.py
@@ -101,10 +101,10 @@ def run_bq_query(
         end_date=end_date,
         fetch_if_missing=True,
     )
-    data_path = entry.data_path()
-    assert data_path is not None
-    stats_path = entry.stats_path()
-    assert stats_path is not None
+    data_path = entry.data_parquet_file_path()
+    assert data_path.exists()
+    stats_path = entry.stats_json_file_path()
+    assert stats_path.exists()
     print(f"✓ Cache entry: {data_path.parent.name}", file=sys.stderr)
     print(f"  Data: {data_path}", file=sys.stderr)
     print(f"  Stats: {stats_path}", file=sys.stderr)

--- a/library/src/iqb/cache/__init__.py
+++ b/library/src/iqb/cache/__init__.py
@@ -359,9 +359,9 @@ class IQBCache:
             start_date,
             end_date,
         )
-        download_data = download_entry.data_path()
-        download_stats = download_entry.stats_path()
-        if download_data is None or download_stats is None:
+        download_data = download_entry.data_parquet_file_path()
+        download_stats = download_entry.stats_json_file_path()
+        if not download_data.exists() or not download_stats.exists():
             raise FileNotFoundError(
                 f"Cache entry not found for downloads_by_{granularity} ({start_date} to {end_date})"
             )
@@ -372,9 +372,9 @@ class IQBCache:
             start_date,
             end_date,
         )
-        upload_data = upload_entry.data_path()
-        upload_stats = upload_entry.stats_path()
-        if upload_data is None or upload_stats is None:
+        upload_data = upload_entry.data_parquet_file_path()
+        upload_stats = upload_entry.stats_json_file_path()
+        if not upload_data.exists() or not upload_stats.exists():
             raise FileNotFoundError(
                 f"Cache entry not found for uploads_by_{granularity} ({start_date} to {end_date})"
             )

--- a/library/src/iqb/pipeline/__init__.py
+++ b/library/src/iqb/pipeline/__init__.py
@@ -242,7 +242,7 @@ class IQBPipeline:
         entry = self.manager.get_cache_entry(template, start_date, end_date)
 
         # 2. make sure the entry exists
-        if entry.data_path() is not None and entry.stats_path() is not None:
+        if entry.data_parquet_file_path().exists() and entry.stats_json_file_path().exists():
             return entry
 
         # 3. handle missing cache without auto-fetching
@@ -259,8 +259,8 @@ class IQBPipeline:
         result.save_stats()
 
         # 5. return information about the cache entry
-        assert entry.data_path() is not None
-        assert entry.stats_path() is not None
+        assert entry.data_parquet_file_path().exists()
+        assert entry.stats_json_file_path().exists()
         return entry
 
     def execute_query_template(

--- a/library/src/iqb/pipeline/cache.py
+++ b/library/src/iqb/pipeline/cache.py
@@ -48,23 +48,13 @@ class PipelineCacheEntry:
         end_dir = self.end_time.strftime(fs_date_format)
         return self.data_dir / "cache" / "v1" / start_dir / end_dir / self.tname.value
 
-    # TODO(bassosimone): returning None here is wrong and a better
-    # approach would be to return the path and let the caller
-    # decide whether the path is actually valid!
+    def data_parquet_file_path(self) -> Path:
+        """Returns the path to the `data.parquet` file."""
+        return self.dir_path() / PIPELINE_CACHE_DATA_FILENAME
 
-    def data_path(self) -> Path | None:
-        """Returns the path to the parquet data file, if it exists, or None."""
-        value = self.dir_path() / PIPELINE_CACHE_DATA_FILENAME
-        if not value.exists():
-            return None
-        return value
-
-    def stats_path(self) -> Path | None:
-        """Returns the path to the JSON stats file, if it exists, or None."""
-        value = self.dir_path() / PIPELINE_CACHE_STATS_FILENAME
-        if not value.exists():
-            return None
-        return value
+    def stats_json_file_path(self) -> Path:
+        """Returns the path to the `stats.json` file."""
+        return self.dir_path() / PIPELINE_CACHE_STATS_FILENAME
 
 
 class PipelineCacheManager:

--- a/library/tests/iqb/pipeline/cache_test.py
+++ b/library/tests/iqb/pipeline/cache_test.py
@@ -224,7 +224,8 @@ class TestPipelineCacheEntry:
         data_file = cache_dir / "data.parquet"
         data_file.write_text("fake data")
 
-        assert entry.data_path() == data_file
+        assert entry.data_parquet_file_path() == data_file
+        assert entry.data_parquet_file_path().exists()
 
     def test_data_path_when_file_missing(self, tmp_path):
         """Test data_path returns None when file doesn't exist."""
@@ -235,7 +236,9 @@ class TestPipelineCacheEntry:
             end_time=datetime(2024, 11, 1),
         )
 
-        assert entry.data_path() is None
+        data_file = entry.dir_path() / "data.parquet"
+        assert entry.data_parquet_file_path() == data_file
+        assert not entry.data_parquet_file_path().exists()
 
     def test_stats_path_when_file_exists(self, tmp_path):
         """Test stats_path returns path when file exists."""
@@ -252,7 +255,8 @@ class TestPipelineCacheEntry:
         stats_file = cache_dir / "stats.json"
         stats_file.write_text("{}")
 
-        assert entry.stats_path() == stats_file
+        assert entry.stats_json_file_path() == stats_file
+        assert entry.stats_json_file_path().exists()
 
     def test_stats_path_when_file_missing(self, tmp_path):
         """Test stats_path returns None when file doesn't exist."""
@@ -263,4 +267,6 @@ class TestPipelineCacheEntry:
             end_time=datetime(2024, 11, 1),
         )
 
-        assert entry.stats_path() is None
+        stats_file = entry.dir_path() / "stats.json"
+        assert entry.stats_json_file_path() == stats_file
+        assert not entry.stats_json_file_path().exists()

--- a/library/tests/iqb/pipeline/pipeline_test.py
+++ b/library/tests/iqb/pipeline/pipeline_test.py
@@ -456,13 +456,11 @@ class TestIQBPipelineGetCacheEntry:
         entry = pipeline.get_cache_entry("downloads_by_country", "2024-10-01", "2024-11-01")
 
         assert isinstance(entry, PipelineCacheEntry)
-        data_path = entry.data_path()
-        assert data_path is not None
+        data_path = entry.data_parquet_file_path()
         assert data_path == cache_dir / "data.parquet"
         assert data_path.exists()
 
-        stats_path = entry.stats_path()
-        assert stats_path is not None
+        stats_path = entry.stats_json_file_path()
         assert stats_path == cache_dir / "stats.json"
         assert stats_path.exists()
 
@@ -547,12 +545,11 @@ class TestIQBPipelineGetCacheEntry:
 
             # Entry should be returned with correct paths
             assert isinstance(entry, PipelineCacheEntry)
-            data_path = entry.data_path()
-            assert data_path is not None
-            stats_path = entry.stats_path()
-            assert stats_path is not None
+            data_path = entry.data_parquet_file_path()
+            stats_path = entry.stats_json_file_path()
             assert data_path == expected_cache_dir / "data.parquet"
             assert stats_path == expected_cache_dir / "stats.json"
+
             # Both files should exist
             assert data_path.exists()
             assert stats_path.exists()


### PR DESCRIPTION
This diff refactors the accessors for getting the `data.parquet` and `stats.json` file paths of `PipelineCacheEntry`.

Before we used to return `None` to imply that the file does not exist, but that was backwards. Consider:

1. the returned `Path` has an `exist` method the caller can invoke

2. the caller may want to *write into* the `Path` if not exists

So, this refactoring unlocks a second use case: knowing the paths in which to write, which, in turn, reduces coupling.

BREAKING CHANGE: renamed `PipelineCacheEntry` `data_path` to `data_parquet_file_path` and `stats_path` to `stats_json_file_path` and updated their return value to be just `Path`.