### PR TITLE
feat(library/pipeline): add iqb_parquet_read

### DIFF
--- a/library/src/iqb/pipeline/__init__.py
+++ b/library/src/iqb/pipeline/__init__.py
@@ -80,5 +80,6 @@ without producing intermediate formats.
 """
 
 from .pipeline import IQBPipeline
+from .pqread import iqb_parquet_read
 
-__all__ = ["IQBPipeline"]
+__all__ = ["IQBPipeline", "iqb_parquet_read"]

--- a/library/src/iqb/pipeline/pqread.py
+++ b/library/src/iqb/pipeline/pqread.py
@@ -1,0 +1,57 @@
+"""Module to efficiently read parquet tables."""
+
+from pathlib import Path
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+
+def iqb_parquet_read(
+    filepath: Path,
+    *,
+    country_code: str | None = None,
+    asn: int | None = None,
+    city: str | None = None,
+    columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """
+    Efficiently read data from a parquet table.
+
+    The filtering is efficient because it happens while reading the physical
+    parquet file from disk using PyArrow filter pushdown.
+
+    Arguments:
+        filepath: path to the parquet file
+        country_code: optionally filter for equality with the given country code.
+        asn: optionally filter for equality with the given ASN.
+        city: optionally filter for equality with the given city name.
+        columns: optionally retain only the selected columns.
+
+    Returns:
+        A pandas DataFrame containing the filtered data.
+
+    Raises:
+        FileNotFoundError if the requested file does not exist.
+        ValueError if one or more of the requested columns do not exist.
+    """
+
+    # 1. setup the reading filters to efficiently skip groups of rows
+    # PyArrow filters: list of tuples (column, operator, value)
+    filters = []
+    if asn is not None:
+        filters.append(("asn", "=", asn))
+    if city is not None:
+        filters.append(("city", "=", city))
+    if country_code is not None:
+        filters.append(("country_code", "=", country_code))
+
+    # 2. load in memory using the filters and potentially cutting the columns
+    # Note: PyArrow requires filters=None (not []) when there are no filters
+    table = pq.read_table(
+        filepath,
+        filters=filters if filters else None,
+        columns=columns,
+    )
+
+    # 3. finally convert to data frame
+    return table.to_pandas()

--- a/library/tests/iqb/pipeline/pqread_test.py
+++ b/library/tests/iqb/pipeline/pqread_test.py
@@ -1,0 +1,70 @@
+"""Tests for the iqb.pipeline.pqread module."""
+
+from pathlib import Path
+
+import pytest
+
+from iqb.pipeline.pqread import iqb_parquet_read
+
+
+def _basepath() -> Path:
+    return Path(__file__).parent.parent.parent.parent.parent
+
+
+def _country_dataset() -> Path:
+    return (
+        _basepath()
+        / "data"
+        / "cache"
+        / "v1"
+        / "20241001T000000Z"
+        / "20241101T000000Z"
+        / "downloads_by_country"
+        / "data.parquet"
+    )
+
+
+class TestIQBParquetRead:
+    """Test for iqb_parquet_read function."""
+
+    def test_country_dataset_simple(self):
+        fullpath = _country_dataset()
+        df = iqb_parquet_read(fullpath)
+        assert len(df) == 236
+        assert len(df.columns) == 29
+
+    def test_country_dataset_with_country_filter(self):
+        fullpath = _country_dataset()
+        df = iqb_parquet_read(fullpath, country_code="IT")
+        assert len(df) == 1
+        assert len(df.columns) == 29
+
+    def test_country_dataset_with_column_filter(self):
+        fullpath = _country_dataset()
+        df = iqb_parquet_read(
+            fullpath,
+            columns=[
+                "country_code",
+                "sample_count",
+                "download_p95",
+                "loss_p95",
+            ],
+        )
+        assert len(df) == 236
+        assert len(df.columns) == 4
+
+    def test_nonexisting_file_throws(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            _ = iqb_parquet_read(tmp_path / "data.parquet")
+
+    def test_nonexisting_column_throws(self):
+        with pytest.raises(ValueError):
+            _ = iqb_parquet_read(_country_dataset(), columns=["antani", "mascetti"])
+
+    def test_asn_filter_with_country_dataset_throws(self):
+        with pytest.raises(ValueError):
+            _ = iqb_parquet_read(_country_dataset(), asn=137)
+
+    def test_city_filter_with_country_dataset_throws(self):
+        with pytest.raises(ValueError):
+            _ = iqb_parquet_read(_country_dataset(), city="Boston")


### PR DESCRIPTION
This code introduces a common function for reading parquet inside the pipeline, adapting previously existing code and ensuring we are testing the implementation with actual parquet files.