### PR TITLE
feat(pipeline): introduce the dataset concept

### DIFF
--- a/library/src/iqb/pipeline/__init__.py
+++ b/library/src/iqb/pipeline/__init__.py
@@ -79,7 +79,16 @@ dumped raw query outputs is fast enough, we can directly access the data
 without producing intermediate formats.
 """
 
+from .dataset import (
+    IQBDatasetGranularity,
+    iqb_dataset_name_for_mlab,
+)
 from .pipeline import IQBPipeline
 from .pqread import iqb_parquet_read
 
-__all__ = ["IQBPipeline", "iqb_parquet_read"]
+__all__ = [
+    "IQBDatasetGranularity",
+    "IQBPipeline",
+    "iqb_dataset_name_for_mlab",
+    "iqb_parquet_read",
+]

--- a/library/src/iqb/pipeline/dataset.py
+++ b/library/src/iqb/pipeline/dataset.py
@@ -1,0 +1,32 @@
+"""Module to construct dataset names."""
+
+from enum import Enum
+
+
+class PipelineDatasetMLabTable(str, Enum):
+    """Enumerate available parquet tables in the m-lab dataset."""
+
+    DOWNLOAD = "downloads"
+    UPLOAD = "uploads"
+
+
+class IQBDatasetGranularity(str, Enum):
+    """Enumerate available dataset granularity."""
+
+    COUNTRY = "by_country"
+    COUNTRY_CITY_ASN = "by_country_city_asn"
+
+
+def iqb_dataset_name_for_mlab(
+    *,
+    granularity: IQBDatasetGranularity,
+    table: PipelineDatasetMLabTable,
+) -> str:
+    """
+    Construct the name of an m-lab dataset.
+
+    Arguments:
+        granularity: the desired dataset granularity
+        table: the specific parquet table to read
+    """
+    return f"{table.value}_{granularity.value}"

--- a/library/tests/iqb/pipeline/dataset_test.py
+++ b/library/tests/iqb/pipeline/dataset_test.py
@@ -1,0 +1,25 @@
+"""Tests for the iqb.pipeline.dataset module."""
+
+from iqb.pipeline.dataset import (
+    IQBDatasetGranularity,
+    PipelineDatasetMLabTable,
+    iqb_dataset_name_for_mlab,
+)
+
+
+class TestIQBDatasetNameForMLab:
+    """Test for iqb_dataset_name_for_mlab function."""
+
+    def test_downloads_by_country(self):
+        value = iqb_dataset_name_for_mlab(
+            granularity=IQBDatasetGranularity.COUNTRY,
+            table=PipelineDatasetMLabTable.DOWNLOAD,
+        )
+        assert value == "downloads_by_country"
+
+    def test_uploads_by_country_city_asn(self):
+        value = iqb_dataset_name_for_mlab(
+            granularity=IQBDatasetGranularity.COUNTRY_CITY_ASN,
+            table=PipelineDatasetMLabTable.UPLOAD,
+        )
+        assert value == "uploads_by_country_city_asn"


### PR DESCRIPTION
We're going to use a flat `v1` cache where all the available datasets (m-lab or not) are in the same directory.

To start preparing the ground for this, I need to conceptually replace the `template` name in pipeline functions to a more generic concept of `dataset_name`.

Additionally, since we don't know a priori whether each dataset will consist of download and upload (they may or may not), we make it more generic and define constructors that are specific to the dataset and return the right string.

In turn, this allows to reduce the coupling between the pipeline, which dictates the on-disk data format, and the cache, which uses pipeline-provided abstractions for reading the cache.

Subsequent pull requests will make use of this change, in fact, to decrease the coupling and separate responsibilities.