### PR TITLE
feat(cache)!: use dataset granularity

### DIFF
--- a/library/src/iqb/__init__.py
+++ b/library/src/iqb/__init__.py
@@ -7,10 +7,17 @@ network measurement data, weight matrices, and quality thresholds.
 from .cache import IQBCache
 from .calculator import IQBCalculator
 from .config import IQB_CONFIG
-from .pipeline import IQBPipeline
+from .pipeline import IQBDatasetGranularity, IQBPipeline
 
 # Backward compatibility alias
 IQB = IQBCalculator
 
-__all__ = ["IQB", "IQBCalculator", "IQBCache", "IQB_CONFIG", "IQBPipeline"]
+__all__ = [
+    "IQB",
+    "IQBCalculator",
+    "IQBCache",
+    "IQB_CONFIG",
+    "IQBPipeline",
+    "IQBDatasetGranularity",
+]
 __version__ = "0.1.0"

--- a/library/tests/iqb/integration_test.py
+++ b/library/tests/iqb/integration_test.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from iqb import IQBCache, IQBCalculator
+from iqb import IQBCache, IQBCalculator, IQBDatasetGranularity
 
 
 class TestIntegration:
@@ -36,7 +36,7 @@ class TestIntegration:
         entry = cache.get_cache_entry(
             start_date="2024-10-01",
             end_date="2024-11-01",
-            granularity="country",
+            granularity=IQBDatasetGranularity.COUNTRY,
         )
 
         # Read download DataFrame for all countries
@@ -99,7 +99,7 @@ class TestIntegration:
         entry = cache.get_cache_entry(
             start_date="2024-10-01",
             end_date="2024-11-01",
-            granularity="country",
+            granularity=IQBDatasetGranularity.COUNTRY,
         )
 
         # Use the high-level API to get a DataFramePair (no percentile binding)


### PR DESCRIPTION
This diff modifies the cache to use the dataset granularity.

With this change implemented, the cache now builds a suitable dataset name for m-lab without knowing details about how it will actually be represented on disk.

This makes the cache more independent of the disk layout, which now is mostly a concern of the pipeline code.

BREAKING CHANGE: `get_cache_entry` now requires the dataset granularity rather than a string.