### PR TITLE
refactor(cache): separate mlab and generic code

### DIFF
--- a/library/src/iqb/cache/__init__.py
+++ b/library/src/iqb/cache/__init__.py
@@ -21,250 +21,14 @@ Example usage:
     cache = IQBCache(data_dir="/shared/iqb-cache")
 """
 
-from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-import pandas as pd
 from dateutil.relativedelta import relativedelta
 
-from ..pipeline import (
-    iqb_dataset_name_for_mlab,
-    iqb_parquet_read,
-)
-from ..pipeline.dataset import IQBDatasetGranularity, PipelineDatasetMLabTable
+from ..pipeline.dataset import IQBDatasetGranularity
 from ..pipeline.pipeline import PipelineCacheManager
-
-
-@dataclass(frozen=True)
-class MLabDataFramePair:
-    """
-    Pair of DataFrames containing M-Lab measurement data.
-
-    This class represents pre-filtered measurement data ready for conversion to
-    various output formats. The DataFrames contain all percentile columns, allowing
-    flexible extraction of any percentile.
-
-    Attributes:
-        download_df: pandas DataFrame with download/latency/loss data
-        upload_df: pandas DataFrame with upload data
-    """
-
-    download: pd.DataFrame
-    upload: pd.DataFrame
-
-    def to_dict(self, *, percentile: int = 95) -> dict[str, float]:
-        """
-        Converts the DataFramePair to a dictionary suitable for IQBCalculator.
-
-        Args:
-            percentile: The percentile to extract (1-99), default 95
-
-        Returns:
-            dict with keys for IQBCalculator:
-            {
-                "download_throughput_mbps": float,
-                "upload_throughput_mbps": float,
-                "latency_ms": float,
-                "packet_loss": float,
-            }
-
-        Raises:
-            ValueError: If the DataFrames don't have exactly one row, or if
-                the required percentile columns don't exist.
-        """
-        # 1. Ensure we have exactly one row in each DataFrame
-        if len(self.download) != 1:
-            raise ValueError(
-                f"Expected exactly 1 row in download DataFrame, but got {len(self.download)} rows"
-            )
-
-        if len(self.upload) != 1:
-            raise ValueError(
-                f"Expected exactly 1 row in upload DataFrame, but got {len(self.upload)} rows"
-            )
-
-        # 2. Construct the percentile column names
-        download_col = f"download_p{percentile}"
-        upload_col = f"upload_p{percentile}"
-        latency_col = f"latency_p{percentile}"
-        loss_col = f"loss_p{percentile}"
-
-        # 3. Check that the percentile columns actually exist
-        for col in [download_col, latency_col, loss_col]:
-            if col not in self.download.columns:
-                raise ValueError(
-                    f"Percentile column '{col}' not found in download data. "
-                    f"Available columns: {list(self.download.columns)}"
-                )
-
-        if upload_col not in self.upload.columns:
-            raise ValueError(
-                f"Percentile column '{upload_col}' not found in upload data. "
-                f"Available columns: {list(self.upload.columns)}"
-            )
-
-        # 4. Extract the single row we need
-        download_row = self.download.iloc[0]
-        upload_row = self.upload.iloc[0]
-
-        # 5. Return the dict with explicit float conversion
-        return {
-            "download_throughput_mbps": float(download_row[download_col]),
-            "upload_throughput_mbps": float(upload_row[upload_col]),
-            "latency_ms": float(download_row[latency_col]),
-            "packet_loss": float(download_row[loss_col]),
-        }
-
-
-@dataclass(frozen=True)
-class MLabCacheEntry:
-    """
-    M-Lab entry inside the data cache.
-
-    Attributes:
-        granularity: granularity used by this dataset
-        start_date: the start date used by this dataset (YYYY-MM-DD; included)
-        end_date: the end date used by this dataset (YYYY-MM-DD; excluded)
-        download_data: full path to data.parquet for download
-        upload_data: full path to data.parquet for upload
-        download_stats: full path to stats.json for download
-        upload_stats: full path to stats.json for upload
-    """
-
-    start_date: str
-    end_date: str
-    granularity: IQBDatasetGranularity
-    download_data: Path
-    upload_data: Path
-    download_stats: Path
-    upload_stats: Path
-
-    def read_download_data_frame(
-        self,
-        *,
-        country_code: str | None = None,
-        asn: int | None = None,
-        city: str | None = None,
-        columns: list[str] | None = None,
-    ) -> pd.DataFrame:
-        """
-        Load the download dataset as a dataframe.
-
-        The arguments allow to select a subset of the entire dataset.
-
-        Arguments:
-          country_code: either None or the desired country code (e.g., "IT")
-          asn: either None or the desired ASN (e.g., 137)
-          city: either None or the desired city (e.g., "Boston")
-          columns: either None (all columns) or list of column names to read
-
-        Return:
-          A pandas DataFrame.
-        """
-        return iqb_parquet_read(
-            self.download_data,
-            country_code=country_code,
-            asn=asn,
-            city=city,
-            columns=columns,
-        )
-
-    def read_upload_data_frame(
-        self,
-        *,
-        country_code: str | None = None,
-        asn: int | None = None,
-        city: str | None = None,
-        columns: list[str] | None = None,
-    ) -> pd.DataFrame:
-        """
-        Load the upload dataset as a dataframe.
-
-        The arguments allow to select a subset of the entire dataset.
-
-        Arguments:
-          country_code: either None or the desired country code (e.g., "IT")
-          asn: either None or the desired ASN (e.g., 137)
-          city: either None or the desired city (e.g., "Boston")
-          columns: either None (all columns) or list of column names to read
-
-        Return:
-          A pandas DataFrame.
-        """
-        return iqb_parquet_read(
-            self.upload_data,
-            country_code=country_code,
-            asn=asn,
-            city=city,
-            columns=columns,
-        )
-
-    def read_data_frame_pair(
-        self,
-        *,
-        country_code: str,
-        city: str | None = None,
-        asn: int | None = None,
-    ) -> MLabDataFramePair:
-        """
-        High-level API: Get filtered download/upload data for specific parameters.
-
-        This method provides a convenient way to get measurement data ready for
-        conversion to IQBCalculator format or other analysis. All the columns are
-        loaded, allowing for flexible extraction later.
-
-        Arguments:
-            country_code: ISO 2-letter country code (e.g., "US", "DE")
-            city: Optional city name (required for "country_city" and "country_city_asn" granularity)
-            asn: Optional ASN number (required for "country_city_asn" granularity)
-
-        Returns:
-            DataFramePair containing filtered download and upload DataFrames
-            with all the original percentile columns
-
-        Raises:
-            ValueError: If the requested granularity is incompatible with the
-                cache granularity (e.g., requesting city with country-level data)
-
-        Example:
-            >>> entry = cache.get_cache_entry("2024-10-01", "2024-11-01", "country")
-            >>> pair = entry.get_data_frame_pair(country_code="US")
-            >>> data_p95 = pair.to_dict(percentile=95)
-            >>> data_p50 = pair.to_dict(percentile=50)
-        """
-        # 1. Validate granularity compatibility
-        if city is not None and "city" not in self.granularity:
-            raise ValueError(
-                f"Cannot filter by city with granularity '{self.granularity}'. "
-                f"Use granularity containing 'city' (e.g., 'country_city')."
-            )
-
-        if asn is not None and "asn" not in self.granularity:
-            raise ValueError(
-                f"Cannot filter by ASN with granularity '{self.granularity}'. "
-                f"Use granularity containing 'asn' (e.g., 'country_asn')."
-            )
-
-        # 2. Read download data with filtering (all columns for flexibility)
-        download_df = self.read_download_data_frame(
-            country_code=country_code,
-            city=city,
-            asn=asn,
-        )
-
-        # 3. Read upload data with filtering (all columns for flexibility)
-        upload_df = self.read_upload_data_frame(
-            country_code=country_code,
-            city=city,
-            asn=asn,
-        )
-
-        # 4. Make and return the pair
-        return MLabDataFramePair(
-            download=download_df,
-            upload=upload_df,
-        )
+from .mlab import MLabCacheEntry, MLabCacheReader
 
 
 class IQBCache:
@@ -279,6 +43,7 @@ class IQBCache:
                 If None, defaults to .iqb/ in current working directory.
         """
         self.manager = PipelineCacheManager(data_dir)
+        self.mlab = MLabCacheReader(self.manager)
 
     @property
     def data_dir(self) -> Path:
@@ -313,49 +78,10 @@ class IQBCache:
             ...     granularity=IQBDatasetGranularity.COUNTRY,
             ... )
         """
-        # 1. check whether the download entry exists
-        download_dataset_name = iqb_dataset_name_for_mlab(
-            granularity=granularity,
-            table=PipelineDatasetMLabTable.DOWNLOAD,
-        )
-        download_entry = self.manager.get_cache_entry(
-            dataset_name=download_dataset_name,
+        return self.mlab.get_cache_entry(
             start_date=start_date,
             end_date=end_date,
-        )
-        download_data = download_entry.data_parquet_file_path()
-        download_stats = download_entry.stats_json_file_path()
-        if not download_data.exists() or not download_stats.exists():
-            raise FileNotFoundError(
-                f"Cache entry not found for {download_dataset_name} ({start_date} to {end_date})"
-            )
-
-        # 2. check whether the upload entry exists
-        upload_dataset_name = iqb_dataset_name_for_mlab(
             granularity=granularity,
-            table=PipelineDatasetMLabTable.UPLOAD,
-        )
-        upload_entry = self.manager.get_cache_entry(
-            dataset_name=upload_dataset_name,
-            start_date=start_date,
-            end_date=end_date,
-        )
-        upload_data = upload_entry.data_parquet_file_path()
-        upload_stats = upload_entry.stats_json_file_path()
-        if not upload_data.exists() or not upload_stats.exists():
-            raise FileNotFoundError(
-                f"Cache entry not found for {upload_dataset_name} ({start_date} to {end_date})"
-            )
-
-        # 4. return the actual cache entry
-        return MLabCacheEntry(
-            granularity=granularity,
-            start_date=start_date,
-            end_date=end_date,
-            download_data=download_data,
-            upload_data=upload_data,
-            download_stats=download_stats,
-            upload_stats=upload_stats,
         )
 
     def get_data(

--- a/library/src/iqb/cache/mlab.py
+++ b/library/src/iqb/cache/mlab.py
@@ -1,0 +1,331 @@
+"""Module for reading the m-lab cache."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from ..pipeline import (
+    iqb_dataset_name_for_mlab,
+    iqb_parquet_read,
+)
+from ..pipeline.dataset import IQBDatasetGranularity, PipelineDatasetMLabTable
+from ..pipeline.pipeline import PipelineCacheManager
+
+
+@dataclass(frozen=True)
+class MLabDataFramePair:
+    """
+    Pair of DataFrames containing M-Lab measurement data.
+
+    This class represents pre-filtered measurement data ready for conversion to
+    various output formats. The DataFrames contain all percentile columns, allowing
+    flexible extraction of any percentile.
+
+    Attributes:
+        download_df: pandas DataFrame with download/latency/loss data
+        upload_df: pandas DataFrame with upload data
+    """
+
+    download: pd.DataFrame
+    upload: pd.DataFrame
+
+    def to_dict(self, *, percentile: int = 95) -> dict[str, float]:
+        """
+        Converts the DataFramePair to a dictionary suitable for IQBCalculator.
+
+        Args:
+            percentile: The percentile to extract (1-99), default 95
+
+        Returns:
+            dict with keys for IQBCalculator:
+            {
+                "download_throughput_mbps": float,
+                "upload_throughput_mbps": float,
+                "latency_ms": float,
+                "packet_loss": float,
+            }
+
+        Raises:
+            ValueError: If the DataFrames don't have exactly one row, or if
+                the required percentile columns don't exist.
+        """
+        # 1. Ensure we have exactly one row in each DataFrame
+        if len(self.download) != 1:
+            raise ValueError(
+                f"Expected exactly 1 row in download DataFrame, but got {len(self.download)} rows"
+            )
+
+        if len(self.upload) != 1:
+            raise ValueError(
+                f"Expected exactly 1 row in upload DataFrame, but got {len(self.upload)} rows"
+            )
+
+        # 2. Construct the percentile column names
+        download_col = f"download_p{percentile}"
+        upload_col = f"upload_p{percentile}"
+        latency_col = f"latency_p{percentile}"
+        loss_col = f"loss_p{percentile}"
+
+        # 3. Check that the percentile columns actually exist
+        for col in [download_col, latency_col, loss_col]:
+            if col not in self.download.columns:
+                raise ValueError(
+                    f"Percentile column '{col}' not found in download data. "
+                    f"Available columns: {list(self.download.columns)}"
+                )
+
+        if upload_col not in self.upload.columns:
+            raise ValueError(
+                f"Percentile column '{upload_col}' not found in upload data. "
+                f"Available columns: {list(self.upload.columns)}"
+            )
+
+        # 4. Extract the single row we need
+        download_row = self.download.iloc[0]
+        upload_row = self.upload.iloc[0]
+
+        # 5. Return the dict with explicit float conversion
+        return {
+            "download_throughput_mbps": float(download_row[download_col]),
+            "upload_throughput_mbps": float(upload_row[upload_col]),
+            "latency_ms": float(download_row[latency_col]),
+            "packet_loss": float(download_row[loss_col]),
+        }
+
+
+@dataclass(frozen=True)
+class MLabCacheEntry:
+    """
+    M-Lab entry inside the data cache.
+
+    Attributes:
+        granularity: granularity used by this dataset
+        start_date: the start date used by this dataset (YYYY-MM-DD; included)
+        end_date: the end date used by this dataset (YYYY-MM-DD; excluded)
+        download_data: full path to data.parquet for download
+        upload_data: full path to data.parquet for upload
+        download_stats: full path to stats.json for download
+        upload_stats: full path to stats.json for upload
+    """
+
+    start_date: str
+    end_date: str
+    granularity: IQBDatasetGranularity
+    download_data: Path
+    upload_data: Path
+    download_stats: Path
+    upload_stats: Path
+
+    def read_download_data_frame(
+        self,
+        *,
+        country_code: str | None = None,
+        asn: int | None = None,
+        city: str | None = None,
+        columns: list[str] | None = None,
+    ) -> pd.DataFrame:
+        """
+        Load the download dataset as a dataframe.
+
+        The arguments allow to select a subset of the entire dataset.
+
+        Arguments:
+          country_code: either None or the desired country code (e.g., "IT")
+          asn: either None or the desired ASN (e.g., 137)
+          city: either None or the desired city (e.g., "Boston")
+          columns: either None (all columns) or list of column names to read
+
+        Return:
+          A pandas DataFrame.
+        """
+        return iqb_parquet_read(
+            self.download_data,
+            country_code=country_code,
+            asn=asn,
+            city=city,
+            columns=columns,
+        )
+
+    def read_upload_data_frame(
+        self,
+        *,
+        country_code: str | None = None,
+        asn: int | None = None,
+        city: str | None = None,
+        columns: list[str] | None = None,
+    ) -> pd.DataFrame:
+        """
+        Load the upload dataset as a dataframe.
+
+        The arguments allow to select a subset of the entire dataset.
+
+        Arguments:
+          country_code: either None or the desired country code (e.g., "IT")
+          asn: either None or the desired ASN (e.g., 137)
+          city: either None or the desired city (e.g., "Boston")
+          columns: either None (all columns) or list of column names to read
+
+        Return:
+          A pandas DataFrame.
+        """
+        return iqb_parquet_read(
+            self.upload_data,
+            country_code=country_code,
+            asn=asn,
+            city=city,
+            columns=columns,
+        )
+
+    def read_data_frame_pair(
+        self,
+        *,
+        country_code: str,
+        city: str | None = None,
+        asn: int | None = None,
+    ) -> MLabDataFramePair:
+        """
+        High-level API: Get filtered download/upload data for specific parameters.
+
+        This method provides a convenient way to get measurement data ready for
+        conversion to IQBCalculator format or other analysis. All the columns are
+        loaded, allowing for flexible extraction later.
+
+        Arguments:
+            country_code: ISO 2-letter country code (e.g., "US", "DE")
+            city: Optional city name (required for "country_city" and "country_city_asn" granularity)
+            asn: Optional ASN number (required for "country_city_asn" granularity)
+
+        Returns:
+            DataFramePair containing filtered download and upload DataFrames
+            with all the original percentile columns
+
+        Raises:
+            ValueError: If the requested granularity is incompatible with the
+                cache granularity (e.g., requesting city with country-level data)
+
+        Example:
+            >>> entry = cache.get_cache_entry("2024-10-01", "2024-11-01", "country")
+            >>> pair = entry.get_data_frame_pair(country_code="US")
+            >>> data_p95 = pair.to_dict(percentile=95)
+            >>> data_p50 = pair.to_dict(percentile=50)
+        """
+        # 1. Validate granularity compatibility
+        if city is not None and "city" not in self.granularity:
+            raise ValueError(
+                f"Cannot filter by city with granularity '{self.granularity}'. "
+                f"Use granularity containing 'city' (e.g., 'country_city')."
+            )
+
+        if asn is not None and "asn" not in self.granularity:
+            raise ValueError(
+                f"Cannot filter by ASN with granularity '{self.granularity}'. "
+                f"Use granularity containing 'asn' (e.g., 'country_asn')."
+            )
+
+        # 2. Read download data with filtering (all columns for flexibility)
+        download_df = self.read_download_data_frame(
+            country_code=country_code,
+            city=city,
+            asn=asn,
+        )
+
+        # 3. Read upload data with filtering (all columns for flexibility)
+        upload_df = self.read_upload_data_frame(
+            country_code=country_code,
+            city=city,
+            asn=asn,
+        )
+
+        # 4. Make and return the pair
+        return MLabDataFramePair(
+            download=download_df,
+            upload=upload_df,
+        )
+
+
+class MLabCacheReader:
+    """Component for reading the M-Lab cache."""
+
+    def __init__(self, manager: PipelineCacheManager):
+        """
+        Initialize cache with data directory path.
+
+        Parameters:
+            manager: the PipelineCacheManager to use.
+        """
+        self.manager = manager
+
+    def get_cache_entry(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+        granularity: IQBDatasetGranularity,
+    ) -> MLabCacheEntry:
+        """
+        Get cache entry associated with given dates and granularity.
+
+        The returned CacheEntry allows you to read raw data as DataFrame.
+
+        Arguments:
+            start_date: start measurement date expressed as YYYY-MM-DD (included)
+            end_date: end measurement date expressed as YYYY-MM-DD (excluded)
+            granularity: the granularity to use
+
+        Return:
+            A CacheEntry instance.
+
+        Example:
+            >>> # Returns data for October 2025
+            >>> entry = cache.get_mlab_cache_entry(
+            ...     start_date="2025-10-01",
+            ...     end_date="2025-11-01",
+            ...     granularity=IQBDatasetGranularity.COUNTRY,
+            ... )
+        """
+        # 1. get the download entry
+        download_dataset_name = iqb_dataset_name_for_mlab(
+            granularity=granularity,
+            table=PipelineDatasetMLabTable.DOWNLOAD,
+        )
+        download_entry = self.manager.get_cache_entry(
+            dataset_name=download_dataset_name,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        download_data = download_entry.data_parquet_file_path()
+        download_stats = download_entry.stats_json_file_path()
+        download_exists = download_data.exists() and download_stats.exists()
+
+        # 2. get the upload entry
+        upload_dataset_name = iqb_dataset_name_for_mlab(
+            granularity=granularity,
+            table=PipelineDatasetMLabTable.UPLOAD,
+        )
+        upload_entry = self.manager.get_cache_entry(
+            dataset_name=upload_dataset_name,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        upload_data = upload_entry.data_parquet_file_path()
+        upload_stats = upload_entry.stats_json_file_path()
+        upload_exists = upload_data.exists() and upload_stats.exists()
+
+        # 3. bail if entries are missing
+        if not download_exists or not upload_exists:
+            raise FileNotFoundError(
+                f"Cache entry not found for {download_dataset_name} {upload_dataset_name}"
+                f" ({start_date} to {end_date})"
+            )
+
+        # 4. return the actual cache entry
+        return MLabCacheEntry(
+            granularity=granularity,
+            start_date=start_date,
+            end_date=end_date,
+            download_data=download_data,
+            upload_data=upload_data,
+            download_stats=download_stats,
+            upload_stats=upload_stats,
+        )

--- a/library/tests/iqb/cache/cache_test.py
+++ b/library/tests/iqb/cache/cache_test.py
@@ -171,10 +171,7 @@ class TestIQBCacheGetData:
         """Test that requesting data for unavailable date raises FileNotFoundError."""
         cache = IQBCache(data_dir=data_dir)
 
-        with pytest.raises(
-            FileNotFoundError,
-            match=r"Cache entry not found for downloads_by_country \(2024-11-01 to 2024-12-01\)",
-        ):
+        with pytest.raises(FileNotFoundError, match=r"Cache entry not found"):
             cache.get_data(country="US", start_date=datetime(2024, 11, 1))
 
 

--- a/library/tests/iqb/cache/mlab_test.py
+++ b/library/tests/iqb/cache/mlab_test.py
@@ -1,0 +1,261 @@
+"""Tests for the iqb.cache.mlab module."""
+
+import pandas as pd
+import pytest
+
+from iqb import IQBDatasetGranularity
+from iqb.cache.mlab import (
+    MLabCacheEntry,
+    MLabCacheReader,
+    MLabDataFramePair,
+)
+from iqb.pipeline.cache import PipelineCacheManager
+
+
+def _create_reader(data_dir: str) -> MLabCacheReader:
+    manager = PipelineCacheManager(data_dir=data_dir)
+    return MLabCacheReader(manager)
+
+
+def _get_country_cache_entry_2024_10(reader: MLabCacheReader) -> MLabCacheEntry:
+    return reader.get_cache_entry(
+        start_date="2024-10-01",
+        end_date="2024-11-01",
+        granularity=IQBDatasetGranularity.COUNTRY,
+    )
+
+
+class TestMLabCacheReaderIntegration:
+    """Integration tests for MLabCacheReader class."""
+
+    def test_read_download_dataframe(self, data_dir):
+        """Test that IQBCache uses .iqb/ directory by default."""
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        download_df = entry.read_download_data_frame()
+
+        assert not download_df.empty
+        assert "country_code" in download_df.columns
+        assert "sample_count" in download_df.columns
+        assert "download_p95" in download_df.columns
+        assert "latency_p95" in download_df.columns
+        assert "loss_p95" in download_df.columns
+        assert len(download_df) == 236
+
+    def test_read_upload_dataframe(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        upload_df = entry.read_upload_data_frame()
+
+        assert not upload_df.empty
+        assert "country_code" in upload_df.columns
+        assert "sample_count" in upload_df.columns
+        assert "upload_p95" in upload_df.columns
+        assert len(upload_df) == 237
+
+    def test_filter_by_country_code(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        us_download_df = entry.read_download_data_frame(country_code="US")
+
+        assert len(us_download_df) == 1
+        assert us_download_df.iloc[0]["country_code"] == "US"
+        assert us_download_df.iloc[0]["sample_count"] == 31443312
+        assert us_download_df.iloc[0]["download_p95"] == 625.6932041848493
+        assert us_download_df.iloc[0]["loss_p95"] == 0.0
+        assert us_download_df.iloc[0]["latency_p95"] == 0.806
+
+        us_upload_df = entry.read_upload_data_frame(country_code="US")
+        assert len(us_upload_df) == 1
+        assert us_upload_df.iloc[0]["country_code"] == "US"
+        assert us_upload_df.iloc[0]["sample_count"] == 24288961
+        assert us_upload_df.iloc[0]["upload_p95"] == 370.487725107692
+
+    def test_column_projection(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        limited_download_df = entry.read_download_data_frame(
+            country_code="US",
+            columns=[
+                "country_code",
+                "sample_count",
+                "download_p50",
+                "latency_p50",
+            ],
+        )
+        assert len(limited_download_df.columns) == 4
+        assert "sample_count" in limited_download_df.columns
+        assert "download_p50" in limited_download_df.columns
+        assert "latency_p50" in limited_download_df.columns
+        assert "loss_p95" not in limited_download_df.columns  # Not requested
+
+    def test_read_multiple_countries(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        countries = ("US", "DE", "BR", "IT", "FR", "IN", "DE")
+        for country_code in countries:
+            ddf = entry.read_download_data_frame(country_code=country_code)
+            assert len(ddf) == 1
+            assert ddf.iloc[0]["country_code"] == country_code
+            assert ddf.iloc[0]["sample_count"] > 0
+            assert ddf.iloc[0]["download_p95"] > 0
+
+            udf = entry.read_upload_data_frame(country_code=country_code)
+            assert len(udf) == 1
+            assert udf.iloc[0]["country_code"] == country_code
+            assert udf.iloc[0]["sample_count"] > 0
+            assert udf.iloc[0]["upload_p95"] > 0
+
+    def test_read_data_frame_pair(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        pair = entry.read_data_frame_pair(country_code="US")
+
+        assert pair is not None
+        assert len(pair.download) == 1
+        assert len(pair.upload) == 1
+
+        assert "download_p95" in pair.download.columns
+        assert "download_p50" in pair.download.columns
+        assert "upload_p95" in pair.upload.columns
+        assert "upload_p50" in pair.upload.columns
+
+    def test_convert_to_dict_p95(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        pair = entry.read_data_frame_pair(country_code="US")
+
+        data_p95 = pair.to_dict(percentile=95)
+
+        assert "download_throughput_mbps" in data_p95
+        assert "upload_throughput_mbps" in data_p95
+        assert "latency_ms" in data_p95
+        assert "packet_loss" in data_p95
+
+        assert isinstance(data_p95["download_throughput_mbps"], float)
+        assert isinstance(data_p95["upload_throughput_mbps"], float)
+        assert isinstance(data_p95["latency_ms"], float)
+        assert isinstance(data_p95["packet_loss"], float)
+
+        assert data_p95["download_throughput_mbps"] == 625.6932041848493
+        assert data_p95["upload_throughput_mbps"] == 370.487725107692
+
+        assert data_p95["latency_ms"] == 0.806
+        assert data_p95["packet_loss"] == 0.0
+
+    def test_convert_to_dict_default_percentile(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        pair = entry.read_data_frame_pair(country_code="US")
+
+        data_p95 = pair.to_dict(percentile=95)
+
+        data_default = pair.to_dict()
+        assert data_default == data_p95
+
+    def test_convert_to_dict_multiple_percentiles(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        pair = entry.read_data_frame_pair(country_code="US")
+
+        data_p95 = pair.to_dict(percentile=95)
+
+        data_p50 = pair.to_dict(percentile=50)
+
+        # Median values should generally be different from p95
+        assert (
+            data_p95["download_throughput_mbps"] != data_p50["download_throughput_mbps"]
+            or data_p95["upload_throughput_mbps"] != data_p50["upload_throughput_mbps"]
+            or data_p95["latency_ms"] != data_p50["latency_ms"]
+            or data_p95["packet_loss"] != data_p50["packet_loss"]
+        )
+
+    def test_read_data_frame_pair_granularity_error_city(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        with pytest.raises(ValueError):
+            _ = entry.read_data_frame_pair(country_code="US", city="Boston")
+
+    def test_read_data_frame_pair_granularity_error_asn(self, data_dir):
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        with pytest.raises(ValueError):
+            _ = entry.read_data_frame_pair(country_code="US", asn=137)
+
+    def test_get_cache_entry_with_missing_on_disk_data(self, tmp_path):
+        reader = _create_reader(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            _ = _get_country_cache_entry_2024_10(reader)
+
+
+class TestMLabDataFramePairExceptions:
+    def test_download_multiple_rows_raises(self):
+        df_download = pd.DataFrame({"download_p95": [100, 200]})
+        df_upload = pd.DataFrame({"upload_p95": [50]})
+        pair = MLabDataFramePair(download=df_download, upload=df_upload)
+
+        with pytest.raises(ValueError, match="Expected exactly 1 row in download DataFrame"):
+            pair.to_dict()
+
+    def test_upload_multiple_rows_raises(self):
+        df_download = pd.DataFrame({"download_p95": [100]})
+        df_upload = pd.DataFrame({"upload_p95": [50, 75]})
+        pair = MLabDataFramePair(download=df_download, upload=df_upload)
+
+        with pytest.raises(ValueError, match="Expected exactly 1 row in upload DataFrame"):
+            pair.to_dict()
+
+    @pytest.mark.parametrize(
+        "missing_column",
+        [
+            "download_p95",
+            "latency_p95",
+            "loss_p95",
+        ],
+    )
+    def test_missing_download_columns_raises(self, missing_column):
+        columns = {"download_p95": [100], "latency_p95": [10], "loss_p95": [0.1]}
+        columns.pop(missing_column)
+        df_download = pd.DataFrame(columns)
+        df_upload = pd.DataFrame({"upload_p95": [50]})
+
+        pair = MLabDataFramePair(download=df_download, upload=df_upload)
+
+        with pytest.raises(ValueError, match=f"Percentile column '{missing_column}'"):
+            pair.to_dict()
+
+    def test_missing_upload_column_raises(self):
+        df_download = pd.DataFrame(
+            {
+                "download_p95": [100],
+                "latency_p95": [10],
+                "loss_p95": [0.1],
+            }
+        )
+        df_upload = pd.DataFrame({"upload_p90": [50]})  # Wrong percentile
+
+        pair = MLabDataFramePair(download=df_download, upload=df_upload)
+
+        with pytest.raises(ValueError, match="Percentile column 'upload_p95'"):
+            pair.to_dict()
+
+    def test_custom_percentile_missing_columns_raises(self):
+        df_download = pd.DataFrame({"download_p50": [100], "latency_p50": [10], "loss_p50": [0.1]})
+        df_upload = pd.DataFrame({"upload_p50": [50]})
+
+        pair = MLabDataFramePair(download=df_download, upload=df_upload)
+
+        # percentile=95 will be missing
+        with pytest.raises(ValueError, match="Percentile column 'download_p95'"):
+            pair.to_dict(percentile=95)


### PR DESCRIPTION
This diff extracts mlab-specific code from the cache package and creates a new module named `mlab.py` to contain it.

There are little to none functional changes here. The main change is a slightly different exception wording when the cache entry is missing.

While there, ensure we have better testing.