### PR TITLE
refactor(cache): move m-lab `get_data` to mlab.py

### DIFF
--- a/library/src/iqb/cache/__init__.py
+++ b/library/src/iqb/cache/__init__.py
@@ -12,9 +12,34 @@ directory, similar to how Git uses `.git/` for repository state. This provides:
 - Per-project isolation (each project has its own cache directory)
 - Conventional pattern (like `.cache/`, `.config/`, etc.)
 
-Example usage:
+⚠️  PERCENTILE INTERPRETATION (CRITICAL!)
+----------------------------------------
 
-    # Uses ./.iqb/ in current directory
+For "higher is better" metrics (throughput):
+  - Raw p95 = "95% of users have ≤ 625 Mbit/s speed"
+  - Directly usable: download_p95 ≥ threshold?
+  - No inversion needed (standard statistical definition)
+
+For "lower is better" metrics (latency, packet loss):
+  - Raw p95 = "95% of users have ≤ 80ms latency" (worst-case typical)
+  - We want p95 to represent best-case typical (to match throughput)
+  - Solution: Use p5 raw labeled as p95
+  - Mathematical inversion: p(X)_labeled = p(100-X)_raw
+  - Example: OFFSET(5) raw → labeled as "latency_p95" in JSON
+
+This inversion happens in BigQuery (see data/query_*.sql),
+so this cache code treats all percentiles uniformly.
+
+When you request percentile=95, you get the 95th percentile value
+that can be compared uniformly against thresholds.
+
+NOTE: This creates semantics where p95 represents "typical best
+performance" - empirical validation will determine if appropriate.
+
+Example usage
+-------------
+
+    # Uses .iqb/ in current directory
     cache = IQBCache()
 
     # Or specify custom location
@@ -95,83 +120,57 @@ class IQBCache:
         Fetch measurement data for IQB calculation.
 
         Args:
-            country: ISO 2-letter country code (e.g., "US", "DE", "BR", "FR", etc.).
+            country: ISO 2-letter country code (e.g., "US").
             start_date: Start of date range (inclusive).
             end_date: End of date range (exclusive). If None, defaults to start_date + 1 month.
             percentile: Which percentile to extract (1-99).
 
         Returns:
             dict with keys for IQBCalculator:
+
             {
-                "download_throughput_mbps": float,
-                "upload_throughput_mbps": float,
-                "latency_ms": float,
-                "packet_loss": float,
+                "m-lab": {
+                    "download_throughput_mbps": float,
+                    "upload_throughput_mbps": float,
+                    "latency_ms": float,
+                    "packet_loss": float,
+                }
             }
 
         Raises:
             FileNotFoundError: If requested data is not available in cache.
             ValueError: If requested percentile is not available in cached data.
-
-        ⚠️  PERCENTILE INTERPRETATION (CRITICAL!)
-        =========================================
-
-        For "higher is better" metrics (throughput):
-          - Raw p95 = "95% of users have ≤ 625 Mbit/s speed"
-          - Directly usable: download_p95 ≥ threshold?
-          - No inversion needed (standard statistical definition)
-
-        For "lower is better" metrics (latency, packet loss):
-          - Raw p95 = "95% of users have ≤ 80ms latency" (worst-case typical)
-          - We want p95 to represent best-case typical (to match throughput)
-          - Solution: Use p5 raw labeled as p95
-          - Mathematical inversion: p(X)_labeled = p(100-X)_raw
-          - Example: OFFSET(5) raw → labeled as "latency_p95" in JSON
-
-        This inversion happens in BigQuery (see data/query_*.sql),
-        so this cache code treats all percentiles uniformly.
-
-        When you request percentile=95, you get the 95th percentile value
-        that can be compared uniformly against thresholds.
-
-        NOTE: This creates semantics where p95 represents "typical best
-        performance" - empirical validation will determine if appropriate.
         """
-        # TODO(bassosimone): we should convert this method to become
-        # a wrapper of `get_cache_entry` in the future.
 
         # Design Note
         # -----------
         #
-        # For now, we are going with separate pipelines producing data for
-        # separate data sources, since this scales well incrementally.
+        # We are going with separate pipelines producing data for separate
+        # data sources, since this scales well incrementally.
         #
         # Additionally, note how the data is relatively small regardless
         # of the time window that we're choosing (it's always four metrics
         # each of which contains between 25 and 100 percentiles). So,
         # computationally, gluing together N datasets in here will never
         # become an expensive operation.
-        #
-        # We may revisit this choice when we approach production readiness.
 
         # 1. Normalize country to be uppercase
         country_upper = country.upper()
 
-        # 2. Create the dictionary with the results
+        # 2. Assign a value to end_date if not set
+        if end_date is None:
+            end_date = start_date + relativedelta(months=1)
+
+        # 3. Create the dictionary with the results
         results = {}
 
-        # TODO(bassosimone): a design choice here is whether we want to
-        # allow for partial data (e.g., we have m-lab data but we do not
-        # have cloudflare data), which happens right now with a static
-        # cache and may also happen when fetching from remote. It is not
-        # an issue right now, since there's just the m-lab data source.
-
-        # 3. Attempt to fill the results with m-lab data
-        results["m-lab"] = self._get_mlab_data(
-            country_upper=country_upper,
-            start_date=start_date,
-            end_date=end_date,
+        # 4. Attempt to fill the results with m-lab data
+        results["m-lab"] = self.mlab.get_data(
+            country_code=country_upper,
+            start_date=start_date.strftime("%Y-%m-%d"),
+            end_date=end_date.strftime("%Y-%m-%d"),
             percentile=percentile,
+            granularity=IQBDatasetGranularity.COUNTRY,
         )
 
         # 4. Attempt to fill the results with cloudflare data
@@ -182,34 +181,3 @@ class IQBCache:
 
         # 6. Return assembled result
         return results
-
-    def _get_mlab_data(
-        self,
-        country_upper: str,
-        start_date: datetime,
-        end_date: datetime | None = None,
-        percentile: int = 95,
-    ) -> dict:
-        """Return m-lab data with the given country code, dates, etc."""
-
-        # 1. Assign a value to end_date if not set
-        if end_date is None:
-            end_date = start_date + relativedelta(months=1)
-
-        # TODO(bassosimone): make it possible to query using
-        # different granularities here
-
-        # 2. Read the on-disk cache
-        entry = self.get_mlab_cache_entry(
-            start_date=start_date.strftime("%Y-%m-%d"),
-            end_date=end_date.strftime("%Y-%m-%d"),
-            granularity=IQBDatasetGranularity.COUNTRY,
-        )
-
-        # 3. Obtain the corresponding download and upload data frames
-        df_pair = entry.read_data_frame_pair(
-            country_code=country_upper,
-        )
-
-        # 4. Convert to dictionary and return
-        return df_pair.to_dict(percentile=percentile)

--- a/library/src/iqb/cache/mlab.py
+++ b/library/src/iqb/cache/mlab.py
@@ -329,3 +329,52 @@ class MLabCacheReader:
             download_stats=download_stats,
             upload_stats=upload_stats,
         )
+
+    def get_data(
+        self,
+        *,
+        granularity: IQBDatasetGranularity,
+        country_code: str,
+        start_date: str,
+        end_date: str,
+        asn: int | None = None,
+        city: str | None = None,
+        percentile: int = 95,
+    ) -> dict[str, float]:
+        """
+        Fetch M-Lab measurement data for IQB calculation.
+
+        Args:
+            country_code: ISO 2-letter country code (e.g., "US").
+            start_date: Start of date range (inclusive) using YYYY-MM-DD format.
+            end_date: End of date range (exclusive) using YYYY-MM-DD format.
+            percentile: Which percentile to extract (1-99).
+
+        Returns:
+            dict with keys for IQBCalculator:
+
+            {
+                "download_throughput_mbps": float,
+                "upload_throughput_mbps": float,
+                "latency_ms": float,
+                "packet_loss": float,
+            }
+
+        Raises:
+            FileNotFoundError: If requested data is not available in cache.
+            ValueError: If requested percentile is not available in cached data.
+        """
+
+        entry = self.get_cache_entry(
+            start_date=start_date,
+            end_date=end_date,
+            granularity=granularity,
+        )
+
+        pair = entry.read_data_frame_pair(
+            country_code=country_code,
+            asn=asn,
+            city=city,
+        )
+
+        return pair.to_dict(percentile=percentile)

--- a/library/tests/iqb/cache/mlab_test.py
+++ b/library/tests/iqb/cache/mlab_test.py
@@ -198,6 +198,22 @@ class TestMLabCacheReaderIntegration:
         with pytest.raises(FileNotFoundError):
             _ = _get_country_cache_entry_2024_10(reader)
 
+    def test_get_data_successful(self, data_dir):
+        reader = _create_reader(data_dir)
+        data = reader.get_data(
+            granularity=IQBDatasetGranularity.COUNTRY,
+            country_code="US",
+            start_date="2024-10-01",
+            end_date="2024-11-01",
+            percentile=95,
+        )
+
+        assert data["download_throughput_mbps"] == 625.6932041848493
+        assert data["upload_throughput_mbps"] == 370.487725107692
+
+        assert data["latency_ms"] == 0.806
+        assert data["packet_loss"] == 0.0
+
 
 class TestMLabDataFramePairExceptions:
     def test_download_multiple_rows_raises(self):


### PR DESCRIPTION
This diff moves the logic for getting m-lab data as a dictionary inside of the `mlab.py` file. Now the `__init__.py` mostly contains generic code, even if we should iterate a bit more on that.