### PR TITLE
fix(cloudbuild.yaml): sync variables with token-exchange

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@
 
 substitutions:
   # Default values, can be overridden when submitting the build
-  _REGION: us-central1
+  _REGION: us-east1
   _REPOSITORY: m-lab
   _SERVICE_NAME: iqb-prototype
   _MEMORY: 1Gi


### PR DESCRIPTION
This diff syncs the `cloudbuild.yaml` variables with token-exchange to overcome build issues.

Thanks to @robertodauria for helping me to debug this.