### PR TITLE
fix(queries): allow for geographical navigation

### DIFF
--- a/data/ghcache.json
+++ b/data/ghcache.json
@@ -1,36 +1,36 @@
 {
   "files": {
     "cache/v1/20241001T000000Z/20241101T000000Z/downloads_by_country_city_asn/data.parquet": {
-      "sha256": "299b0ec13c673f5d31a7e5cb5b8a9fbda660ce605fcdff39abe73169c7c17b41",
-      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/299b0ec13c67__cache__v1__20241001T000000Z__20241101T000000Z__downloads_by_country_city_asn__data.parquet"
+      "sha256": "660bb88bb312c078825891aad07c62254fb8980a58d8feefa8d952f3a0574da3",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/660bb88bb312__cache__v1__20241001T000000Z__20241101T000000Z__downloads_by_country_city_asn__data.parquet"
     },
     "cache/v1/20241001T000000Z/20241101T000000Z/downloads_by_country_city_asn/stats.json": {
-      "sha256": "f895676e67e516d91e27f30d3b91e2d13d946e6f1c3b410dced4d1e18888eb3e",
-      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/f895676e67e5__cache__v1__20241001T000000Z__20241101T000000Z__downloads_by_country_city_asn__stats.json"
+      "sha256": "5944e09eb9fc368580b4a8239321287845df5739c0d2a40dc823b149d1477712",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/5944e09eb9fc__cache__v1__20241001T000000Z__20241101T000000Z__downloads_by_country_city_asn__stats.json"
     },
     "cache/v1/20241001T000000Z/20241101T000000Z/uploads_by_country_city_asn/data.parquet": {
-      "sha256": "5ddb0f9d167d8e9b6de6ba7ce7e64eb5bd5a70f92a526ca3069979dbcf687948",
-      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/5ddb0f9d167d__cache__v1__20241001T000000Z__20241101T000000Z__uploads_by_country_city_asn__data.parquet"
+      "sha256": "16ae9791803cfcebd17b8870df4b1edecb57140173ca36fced9192a93dec9846",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/16ae9791803c__cache__v1__20241001T000000Z__20241101T000000Z__uploads_by_country_city_asn__data.parquet"
     },
     "cache/v1/20241001T000000Z/20241101T000000Z/uploads_by_country_city_asn/stats.json": {
-      "sha256": "6c0db9078c72dba89a8905636d891626b28db87c83d89e2db0c9b61c5d0f8484",
-      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/6c0db9078c72__cache__v1__20241001T000000Z__20241101T000000Z__uploads_by_country_city_asn__stats.json"
+      "sha256": "18484d97e2eba1e711263dbde7a0a222a7a7f1b8b8d8f259ceec0c6f20d4c502",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/18484d97e2eb__cache__v1__20241001T000000Z__20241101T000000Z__uploads_by_country_city_asn__stats.json"
     },
     "cache/v1/20251001T000000Z/20251101T000000Z/downloads_by_country_city_asn/data.parquet": {
-      "sha256": "ae4b63315688d5e181434c4075f2155f7040d0ec4e2e5764d523f4995b2cab17",
-      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/ae4b63315688__cache__v1__20251001T000000Z__20251101T000000Z__downloads_by_country_city_asn__data.parquet"
+      "sha256": "2cfb7a8f3c3b851907a46971f1fda8154c713bf024e9b4f5c79710522eccafc3",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/2cfb7a8f3c3b__cache__v1__20251001T000000Z__20251101T000000Z__downloads_by_country_city_asn__data.parquet"
     },
     "cache/v1/20251001T000000Z/20251101T000000Z/downloads_by_country_city_asn/stats.json": {
-      "sha256": "ad04cf493eb1a5b56f71ca75435bc1277be76015a9120bc2382562edf8813cc9",
-      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/ad04cf493eb1__cache__v1__20251001T000000Z__20251101T000000Z__downloads_by_country_city_asn__stats.json"
+      "sha256": "4782085802e0d364db2807da33476ac5f91b91c128c2b8f5028742b922808e5e",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/4782085802e0__cache__v1__20251001T000000Z__20251101T000000Z__downloads_by_country_city_asn__stats.json"
     },
     "cache/v1/20251001T000000Z/20251101T000000Z/uploads_by_country_city_asn/data.parquet": {
-      "sha256": "36a8b75d123dede83c78b96b305ac1ab54a3c52d59533cb085c0e2c97c6e754b",
-      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/36a8b75d123d__cache__v1__20251001T000000Z__20251101T000000Z__uploads_by_country_city_asn__data.parquet"
+      "sha256": "9687c5a93ccaa4b10e2476e46e4fb8ee3c0b2d1c0f847c8ff44bf215e59c82a0",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/9687c5a93cca__cache__v1__20251001T000000Z__20251101T000000Z__uploads_by_country_city_asn__data.parquet"
     },
     "cache/v1/20251001T000000Z/20251101T000000Z/uploads_by_country_city_asn/stats.json": {
-      "sha256": "8ba2a3d857929c4bbc476f9f4b64cf4bb6519392320d95d50f17764e843a4949",
-      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/8ba2a3d85792__cache__v1__20251001T000000Z__20251101T000000Z__uploads_by_country_city_asn__stats.json"
+      "sha256": "44c1347cae3d1b1c1ee74ace7f1cab047765d0a92cb7ec0ff3ec5bbebb0f9c6d",
+      "url": "https://github.com/m-lab/iqb/releases/download/v0.1.0/44c1347cae3d__cache__v1__20251001T000000Z__20251101T000000Z__uploads_by_country_city_asn__stats.json"
     }
   },
   "v": 0

--- a/library/src/iqb/pipeline/__init__.py
+++ b/library/src/iqb/pipeline/__init__.py
@@ -47,6 +47,10 @@ The `{since}` timestamp is included and the `{until}` one is excluded. This
 simplifies specifying time ranges significantly (e.g., October 2025 is
 represented using `since=20251001T000000Z` and `until=20251101T000000Z`).
 
+The *current* implementation of the pipline enforces YYYY-MM-DD dates
+because the underlying queries only support dates. Yet, we design the data
+format to accommodate for more fine grained time intervals in the future.
+
 Note that when using BigQuery the second component of the path will always
 be `T000000Z` because we do not support hourly range queries for now.
 

--- a/library/src/iqb/queries/downloads_by_country_city_asn.sql
+++ b/library/src/iqb/queries/downloads_by_country_city_asn.sql
@@ -1,5 +1,7 @@
 SELECT
     client.Geo.CountryCode as country_code,
+    client.Geo.Subdivision1ISOCode as subdivision1_iso_code,
+    client.Geo.Subdivision1Name as subdivision1_name,
     client.Geo.city as city,
     client.Network.ASNumber as asn,
     client.Network.ASName as as_name,
@@ -73,11 +75,13 @@ FROM
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"
     AND client.Geo.CountryCode IS NOT NULL
+    AND client.Geo.Subdivision1ISOCode IS NOT NULL
+    AND client.Geo.Subdivision1Name IS NOT NULL
     AND client.Geo.city IS NOT NULL
     AND client.Network.ASNumber IS NOT NULL
     AND client.Network.ASName IS NOT NULL
     AND a.MeanThroughputMbps IS NOT NULL
     AND a.MinRTT IS NOT NULL
     AND a.LossRate IS NOT NULL
-GROUP BY country_code, city, asn, as_name
-ORDER BY country_code, city, asn, as_name
+GROUP BY country_code, subdivision1_iso_code, subdivision1_name, city, asn, as_name
+ORDER BY country_code, subdivision1_iso_code, subdivision1_name, city, asn, as_name

--- a/library/src/iqb/queries/uploads_by_country_city_asn.sql
+++ b/library/src/iqb/queries/uploads_by_country_city_asn.sql
@@ -1,5 +1,7 @@
 SELECT
     client.Geo.CountryCode as country_code,
+    client.Geo.Subdivision1ISOCode as subdivision1_iso_code,
+    client.Geo.Subdivision1Name as subdivision1_name,
     client.Geo.city as city,
     client.Network.ASNumber as asn,
     client.Network.ASName as as_name,
@@ -33,9 +35,11 @@ FROM
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"
     AND client.Geo.CountryCode IS NOT NULL
+    AND client.Geo.Subdivision1ISOCode IS NOT NULL
+    AND client.Geo.Subdivision1Name IS NOT NULL
     AND client.Geo.city IS NOT NULL
     AND client.Network.ASNumber IS NOT NULL
     AND client.Network.ASName IS NOT NULL
     AND a.MeanThroughputMbps IS NOT NULL
-GROUP BY country_code, city, asn, as_name
-ORDER BY country_code, city, asn, as_name
+GROUP BY country_code, subdivision1_iso_code, subdivision1_name, city, asn, as_name
+ORDER BY country_code, subdivision1_iso_code, subdivision1_name, city, asn, as_name


### PR DESCRIPTION
To navigate from country to subdivision1 to city we need to have both country and subdivision1 inside city, otherwise it's not possible to filter the more-fine-grained data frame.

For example, we may start with Italy. If we want to focus on, say, Liguria, we need to have both Italy and Liguria in the subdivision1 parquet table. Then, to go from that to Italy/Liguria/Genoa we need both Italy and Liguria inside of the city table, to be able to filter.

So, to address this issue, with this commit, I have added the subdivision1 to the city-level queries.

While there, improve the documentation of the cache disk layout and explain how we could implement downsampling.