### PR TITLE
feat(pipeline): introduce RemoteCache

### DIFF
--- a/library/src/iqb/pipeline/__init__.py
+++ b/library/src/iqb/pipeline/__init__.py
@@ -19,6 +19,28 @@ the on-disk cache data structure. The cache package, which reads the
 cache, conforms to the expected data structure by using code in
 this package that hides the specific implementation details.
 
+Remote Cache Support
+--------------------
+
+The pipeline supports an optional remote cache layer that sits between the
+local cache and BigQuery. When provided, the pipeline will attempt to fetch
+missing cache entries from the remote cache before executing expensive
+BigQuery queries.
+
+The remote cache is implemented as a Protocol (see `pipeline.RemoteCache`)
+that requires a `sync(entry: PipelineCacheEntry) -> bool` method. This
+design allows pluggable remote cache implementations (e.g., GCS, GitHub
+releases, S3) without coupling the pipeline to specific storage backends.
+
+Cache lookup order:
+1. Local disk cache (fast, free)
+2. Remote cache if provided (medium speed, cheap)
+3. BigQuery query (slow, expensive)
+
+This architecture enables sharing pre-computed query results across team
+members and CI/CD environments, significantly reducing BigQuery costs and
+query execution time for common datasets.
+
 Data Directory Convention
 -------------------------
 

--- a/library/src/iqb/pipeline/bqpq.py
+++ b/library/src/iqb/pipeline/bqpq.py
@@ -124,7 +124,7 @@ class PipelineBQPQClient:
         Initialize client with BigQuery project ID.
 
         Parameters:
-            project: BigQuery project.
+            project: billing BigQuery project.
         """
         self.client = bigquery.Client(project=project)
         self.bq_read_clnt = bigquery_storage_v1.BigQueryReadClient()


### PR DESCRIPTION
This diff introduces a `RemoteCache` protocol that one can optionally provide to the `IQBPipeline.get_cache_entry` method using the optional `remote_cache` key-value argument.

If the key-value argument is `None`, the code behaves as before: check locally and otherwise invoke BigQuery.

Otherwise, before invoking BigQuery, we attempt to fetch the cache entry from the `remote_cache` (e.g., a GCS bucket).

Realistically, the first implementation of this protocol will fetch cache entries from GitHub releases, this allowing us to replace the functional dependency on `./data/ghcache.py sync`.

Also, note that this diff proceeds incrementally. It does not ask the question of how the functionality of `./data/ghcache.py scan` (and the related manual upload to GitHub) would be integrated with the library. We want to automate the fetching part first. Once that is done, we will also consider the problem of writing to the remote cache.