### PR TITLE
feat(library): add ghremote package

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -40,7 +40,8 @@ iqb.print_config()
 
 ## Running Tests
 
-The library uses pytest for testing. Tests are located in the `tests/` directory and follow the `*_test.py` naming convention.
+The library uses `pytest` for testing. Tests are located in the `tests/`
+directory and follow the `*_test.py` naming convention.
 
 ```bash
 # From the repository root, sync dev dependencies
@@ -59,15 +60,20 @@ uv run pytest tests/iqb_score_test.py
 # Run specific test class or function
 uv run pytest tests/iqb_score_test.py::TestIQBInitialization
 uv run pytest tests/iqb_score_test.py::TestIQBInitialization::test_init_with_name
+
+# Get coverage
+uv run pytest --cov=.
 ```
 
 ## Code Quality Tools
 
-The library uses Ruff for linting/formatting and Pyright for type checking.
+The library uses `ruff` for linting/formatting and
+`pyright` for type checking.
 
 ### Linting with Ruff
 
-Ruff is a fast Python linter that checks code style, potential bugs, and code quality issues:
+Ruff is a fast Python linter that checks code style, potential
+bugs, and code quality issues:
 
 ```bash
 # From the library directory
@@ -105,7 +111,8 @@ uv run pyright --verbose
 
 **Verifying Pyright is Working:**
 
-Pyright can be silent if misconfigured. To verify it's actually checking your code:
+Pyright can be silent if misconfigured. To verify it's actually
+checking your code:
 
 ```bash
 # This should show which files are being analyzed
@@ -118,7 +125,7 @@ uv run pyright --verbose
 # - "X errors, Y warnings, Z informations"
 ```
 
-If you see "Found 0 source files", the configuration is wrong.
+If you see `"Found 0 source files"`, the configuration is wrong.
 
 To test that Pyright catches errors, temporarily introduce a type error:
 
@@ -127,7 +134,8 @@ To test that Pyright catches errors, temporarily introduce a type error:
 x: int = "this should fail"  # Pyright should catch this!
 ```
 
-If Pyright reports an error, it's working correctly. Remove the test line afterwards.
+If Pyright reports an error, it's working correctly. Remove the
+test line afterwards.
 
 Pyright configuration is in `pyproject.toml` under `[tool.pyright]`.
 
@@ -135,7 +143,8 @@ Pyright configuration is in `pyproject.toml` under `[tool.pyright]`.
 
 ### Adding New Tests
 
-Create new test files in the `tests/` directory following the naming pattern `*_test.py`:
+Create new test files in the `tests/` directory following the
+naming pattern `*_test.py`:
 
 ```python
 """tests/my_feature_test.py"""
@@ -151,4 +160,6 @@ class TestMyFeature:
 
 ### Running Tests in CI
 
-Tests run automatically on all pushes and pull requests to the main branch via GitHub Actions. See `.github/workflows/ci.yml` for the CI configuration.
+Tests run automatically on all pushes and pull requests to the
+`main` branch via GitHub Actions. See `.github/workflows/ci.yml`
+for the CI configuration.

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pandas>=2.0.0",
     "db-dtypes>=1.0.0",
     "python-dateutil>=2.9.0.post0",
+    "dacite>=1.9.2",
 ]
 
 [project.urls]

--- a/library/src/iqb/ghremote/__init__.py
+++ b/library/src/iqb/ghremote/__init__.py
@@ -1,0 +1,28 @@
+"""
+GitHub remote cache synchronization tool for IQB data files.
+
+This is a throwaway module for the initial phase of the project. It will
+eventually be replaced by a proper GCS-based solution.
+
+Manifest format:
+
+{
+  "v": 0,
+  "files": {
+    "cache/v1/.../data.parquet": {
+      "sha256": "3a421c62179a...",
+      "url": "https://github.com/.../3a421c62179a__cache__v1__...parquet"
+    }
+  }
+}
+"""
+
+from .cache import (
+    IQBGitHubRemoteCache,
+    iqb_github_load_manifest,
+)
+
+__all__ = [
+    "IQBGitHubRemoteCache",
+    "iqb_github_load_manifest",
+]

--- a/library/src/iqb/ghremote/cache.py
+++ b/library/src/iqb/ghremote/cache.py
@@ -1,0 +1,140 @@
+"""Module containing the RemoteCache implementation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.request import urlopen
+
+from dacite import from_dict
+
+from ..pipeline.cache import PipelineCacheEntry
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """Entry in the manifest for a single cached file."""
+
+    sha256: str
+    url: str
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """Manifest for cached files stored in GitHub releases."""
+
+    v: int
+    files: dict[str, FileEntry] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.v != 0:
+            raise ValueError(f"Unsupported manifest version: {self.v} (only v=0 supported)")
+
+    def get_file_entry(self, *, full_path: Path, data_dir: Path) -> FileEntry:
+        """
+        Return the file entry corresponding to a given full path and data directory.
+
+        Raises:
+            KeyError: if the given remote entry does not exist.
+        """
+        # Use .as_posix() to ensure forward slashes for cross-platform compatibility
+        # Manifest keys should always use forward slashes regardless of OS
+        key = full_path.relative_to(data_dir).as_posix()
+        try:
+            return self.files[key]
+        except KeyError as exc:
+            raise KeyError(f"no remotely-cached file for {key}") from exc
+
+
+def iqb_github_load_manifest(manifest_file: Path) -> Manifest:
+    """Load manifest from the given file, or return empty manifest if not found."""
+    if not manifest_file.exists():
+        return Manifest(v=0, files={})
+
+    with open(manifest_file) as filep:
+        data = json.load(filep)
+
+    return from_dict(Manifest, data)
+
+
+class IQBGitHubRemoteCache:
+    """
+    Remote cache for query results using GitHub releases.
+
+    This class implements the pipeline.RemoteCache protocol.
+    """
+
+    def __init__(self, manifest: Manifest) -> None:
+        self.manifest = manifest
+
+    def sync(self, entry: PipelineCacheEntry) -> bool:
+        """
+        Sync remote cache entry to disk and return whether
+        we successfully synced it or not. Emits logging messages
+        explaining what it is doing and warning about issues
+        occurred while trying to sync from the remote.
+        """
+        try:
+            logging.info(f"ghremote: syncing {entry}... start")
+            self._sync(entry)
+            logging.info(f"ghremote: syncing {entry}... ok")
+            return True
+        except Exception as exc:
+            logging.warning(f"ghremote: syncing {entry}... failure: {exc}")
+            return False
+
+    def _sync(self, entry: PipelineCacheEntry):
+        # Lookup files in the manifest using pipeline-provided paths
+        # so we don't need to revalidate them again.
+        parquet_entry = self.manifest.get_file_entry(
+            full_path=entry.data_parquet_file_path(),
+            data_dir=entry.data_dir,
+        )
+        json_entry = self.manifest.get_file_entry(
+            full_path=entry.stats_json_file_path(),
+            data_dir=entry.data_dir,
+        )
+
+        # Sync both entries given preference to the JSON since it's smaller
+        # and leads to less wasted bandwidth if the parquet doesn't exist.
+        _sync_file_entry(json_entry, entry.stats_json_file_path())
+        _sync_file_entry(parquet_entry, entry.data_parquet_file_path())
+
+
+def _sync_file_entry(entry: FileEntry, dest_path: Path):
+    """Sync the given FileEntry with the file cached in a GitHub release."""
+    # Determine whether we need to download again
+    exists = dest_path.exists()
+    if not exists or entry.sha256 != _compute_sha256(dest_path):
+        # If old file exists, remove it
+        if exists:
+            os.unlink(dest_path)
+
+        # Download into the destination file directly
+        logging.info(f"ghremote: fetching {entry}... start")
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        with urlopen(entry.url) as response, open(dest_path, "wb") as fp:
+            while chunk := response.read(8192):
+                fp.write(chunk)
+        logging.info(f"ghremote: fetching {entry}... ok")
+
+        # Make sure the sha256 matches
+        logging.info(f"ghremote: validating {entry}... start")
+        sha256 = _compute_sha256(dest_path)
+        if sha256 != entry.sha256:
+            os.unlink(dest_path)
+            raise ValueError(f"SHA256 mismatch: expected {entry.sha256}, got {sha256}")
+        logging.info(f"ghremote: validating {entry}... ok")
+
+
+def _compute_sha256(path: Path) -> str:
+    """Compute SHA256 hash of a file."""
+    sha256 = hashlib.sha256()
+    with open(path, "rb") as fp:
+        while chunk := fp.read(8192):
+            sha256.update(chunk)
+    return sha256.hexdigest()

--- a/library/src/iqb/pipeline/bqpq.py
+++ b/library/src/iqb/pipeline/bqpq.py
@@ -60,8 +60,9 @@ class PipelineBQPQQueryResult:
         parquet_path = self.paths_provider.data_parquet_file_path()
         parquet_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Note: using .as_posix to avoid paths with backslashes
-        # that can cause issues with PyArrow on Windows
+        # Note: using .as_posix() for consistency with forward slashes across platforms.
+        # Modern PyArrow likely handles native Windows paths fine, but this is defensive
+        # programming that ensures compatibility without harm.
         posix_path = parquet_path.as_posix()
 
         # Access the first batch to obtain the schema

--- a/library/tests/iqb/cache/cache_test.py
+++ b/library/tests/iqb/cache/cache_test.py
@@ -1,4 +1,4 @@
-"""Tests for the IQBCache data fetching module."""
+"""Tests for the iqb.cache.cache module."""
 
 from datetime import datetime
 

--- a/library/tests/iqb/ghremote/__init__.py
+++ b/library/tests/iqb/ghremote/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the iqb.ghremote package."""

--- a/library/tests/iqb/ghremote/cache_test.py
+++ b/library/tests/iqb/ghremote/cache_test.py
@@ -1,0 +1,425 @@
+"""Tests for the iqb.ghremote.cache module."""
+
+import hashlib
+import json
+import logging
+from unittest.mock import Mock, patch
+from urllib.error import URLError
+
+import pytest
+from dacite.exceptions import WrongTypeError
+
+from iqb.ghremote.cache import (
+    FileEntry,
+    IQBGitHubRemoteCache,
+    Manifest,
+    iqb_github_load_manifest,
+)
+
+
+def _compute_test_sha256(content: bytes) -> str:
+    """Helper to compute SHA256 for test data."""
+    return hashlib.sha256(content).hexdigest()
+
+
+class TestIQBGitHubLoadManifest:
+    """Tests for loading the iqb_github_load_manifest function."""
+
+    def test_load_invalid_json_string(self, tmp_path):
+        """Verify we get JSONDecodeError when loading an invalid JSON string."""
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text("{ invalid json }")
+
+        with pytest.raises(json.JSONDecodeError):
+            iqb_github_load_manifest(manifest_file)
+
+    def test_load_invalid_json_fields_types(self, tmp_path):
+        """Verify that dacite throws if the fields have invalid types."""
+        manifest_file = tmp_path / "manifest.json"
+        # v should be int, not string
+        manifest_file.write_text('{"v": "not an int", "files": {}}')
+
+        with pytest.raises((WrongTypeError, ValueError, TypeError)):
+            iqb_github_load_manifest(manifest_file)
+
+    def test_load_invalid_version_number(self, tmp_path):
+        """Verify that there is a ValueError when the version number is invalid."""
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text('{"v": 1, "files": {}}')
+
+        with pytest.raises(ValueError, match="Unsupported manifest version"):
+            iqb_github_load_manifest(manifest_file)
+
+    def test_load_success_with_file(self, tmp_path):
+        """Verify that we can correctly load a manifest when backed by an existing file."""
+        manifest_file = tmp_path / "manifest.json"
+        manifest_data = {
+            "v": 0,
+            "files": {
+                "cache/v1/2024-01-01/2024-01-31/test/data.parquet": {
+                    "sha256": "abc123def456",
+                    "url": "https://example.com/file.parquet",
+                }
+            },
+        }
+        manifest_file.write_text(json.dumps(manifest_data))
+
+        manifest = iqb_github_load_manifest(manifest_file)
+
+        assert manifest.v == 0
+        assert len(manifest.files) == 1
+        assert "cache/v1/2024-01-01/2024-01-31/test/data.parquet" in manifest.files
+        entry = manifest.files["cache/v1/2024-01-01/2024-01-31/test/data.parquet"]
+        assert entry.sha256 == "abc123def456"
+        assert entry.url == "https://example.com/file.parquet"
+
+    def test_load_success_without_file(self, tmp_path):
+        """Verify that we return a default manifest when the file is missing."""
+        manifest_file = tmp_path / "nonexistent.json"
+
+        manifest = iqb_github_load_manifest(manifest_file)
+
+        assert manifest.v == 0
+        assert len(manifest.files) == 0
+
+
+class TestManifestGetFileEntry:
+    """Tests for the Manifest.get_file_entry method."""
+
+    def test_success(self, tmp_path):
+        """Verify that we get a FileEntry when the entry exists."""
+        # Create a manifest with a file entry
+        entry = FileEntry(sha256="abc123def456", url="https://example.com/file.parquet")
+        manifest = Manifest(
+            v=0,
+            files={"cache/v1/2024-01-01/2024-01-31/test/data.parquet": entry},
+        )
+
+        # Set up paths - using tmp_path to ensure they're realistic
+        data_dir = tmp_path / "data"
+        full_path = data_dir / "cache/v1/2024-01-01/2024-01-31/test/data.parquet"
+
+        # Get the entry
+        result = manifest.get_file_entry(full_path=full_path, data_dir=data_dir)
+
+        # Verify it's the same entry
+        assert result == entry
+        assert result.sha256 == "abc123def456"
+        assert result.url == "https://example.com/file.parquet"
+
+    def test_failure(self, tmp_path):
+        """Verify that we raise KeyError when the entry does not exist."""
+        # Create an empty manifest
+        manifest = Manifest(v=0, files={})
+
+        # Set up paths
+        data_dir = tmp_path / "data"
+        full_path = data_dir / "cache/v1/2024-01-01/2024-01-31/test/data.parquet"
+
+        # Should raise KeyError with the relative path in the message
+        expected_key = "cache/v1/2024-01-01/2024-01-31/test/data.parquet"
+        with pytest.raises(KeyError, match=f"no remotely-cached file for {expected_key}"):
+            manifest.get_file_entry(full_path=full_path, data_dir=data_dir)
+
+
+class TestIQBGitHubRemoteCacheSync:
+    """Tests for the IQBGitHubRemoteCache.sync method."""
+
+    def _create_mock_entry(self, tmp_path):
+        """Helper to create a mock PipelineCacheEntry."""
+        entry = Mock()
+        entry.data_dir = tmp_path
+        entry.data_parquet_file_path.return_value = tmp_path / "data.parquet"
+        entry.stats_json_file_path.return_value = tmp_path / "stats.json"
+        return entry
+
+    def _mock_urlopen_with_content(self, json_content, parquet_content):
+        """Helper to create urlopen mock that returns specified content."""
+
+        def mock_urlopen(url):
+            # Determine which content to return based on URL
+            content = json_content if "stats.json" in url else parquet_content
+
+            # Create mock response with explicit context manager support
+            response = Mock()
+            response.read = Mock(side_effect=[content, b""])
+            response.__enter__ = Mock(return_value=response)
+            response.__exit__ = Mock(return_value=False)
+            return response
+
+        return mock_urlopen
+
+    def test_missing_parquet_entry(self, tmp_path, caplog):
+        """Make sure we return False if there's no remote parquet entry."""
+        entry = self._create_mock_entry(tmp_path)
+
+        # Manifest only has JSON, not parquet
+        manifest = Manifest(
+            v=0,
+            files={
+                "stats.json": FileEntry(sha256="abc123", url="https://example.com/stats.json"),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        with caplog.at_level(logging.WARNING):
+            result = cache.sync(entry)
+
+        assert result is False
+        assert "failure" in caplog.text
+        assert "no remotely-cached file for data.parquet" in caplog.text
+
+    def test_missing_json_entry(self, tmp_path, caplog):
+        """Make sure we return False if there's no remote JSON entry."""
+        entry = self._create_mock_entry(tmp_path)
+
+        # Manifest only has parquet, not JSON
+        manifest = Manifest(
+            v=0,
+            files={
+                "data.parquet": FileEntry(sha256="abc123", url="https://example.com/data.parquet"),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        with caplog.at_level(logging.WARNING):
+            result = cache.sync(entry)
+
+        assert result is False
+        assert "failure" in caplog.text
+        assert "no remotely-cached file for stats.json" in caplog.text
+
+    def test_download_if_not_exists(self, tmp_path):
+        """Ensure that we download the file if it does not exist."""
+        json_content = b'{"test": "data"}'
+        parquet_content = b"PARQUET_DATA"
+        json_sha256 = _compute_test_sha256(json_content)
+        parquet_sha256 = _compute_test_sha256(parquet_content)
+
+        entry = self._create_mock_entry(tmp_path)
+
+        manifest = Manifest(
+            v=0,
+            files={
+                "data.parquet": FileEntry(
+                    sha256=parquet_sha256, url="https://example.com/data.parquet"
+                ),
+                "stats.json": FileEntry(sha256=json_sha256, url="https://example.com/stats.json"),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        mock_urlopen = self._mock_urlopen_with_content(json_content, parquet_content)
+
+        with patch("iqb.ghremote.cache.urlopen", side_effect=mock_urlopen):
+            result = cache.sync(entry)
+
+        # Verify success
+        assert result is True
+        assert entry.stats_json_file_path().exists()
+        assert entry.data_parquet_file_path().exists()
+        assert entry.stats_json_file_path().read_bytes() == json_content
+        assert entry.data_parquet_file_path().read_bytes() == parquet_content
+
+    def test_no_download_if_exists_and_correct_sha256(self, tmp_path):
+        """Ensure that we do not re-download a file we already downloaded."""
+        json_content = b'{"test": "data"}'
+        parquet_content = b"PARQUET_DATA"
+        json_sha256 = _compute_test_sha256(json_content)
+        parquet_sha256 = _compute_test_sha256(parquet_content)
+
+        entry = self._create_mock_entry(tmp_path)
+
+        # Pre-create files with correct content
+        entry.stats_json_file_path().write_bytes(json_content)
+        entry.data_parquet_file_path().write_bytes(parquet_content)
+
+        manifest = Manifest(
+            v=0,
+            files={
+                "data.parquet": FileEntry(
+                    sha256=parquet_sha256, url="https://example.com/data.parquet"
+                ),
+                "stats.json": FileEntry(sha256=json_sha256, url="https://example.com/stats.json"),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        # Mock urlopen - it should NOT be called
+        mock_urlopen = Mock(side_effect=AssertionError("Should not download!"))
+
+        with patch("iqb.ghremote.cache.urlopen", side_effect=mock_urlopen):
+            result = cache.sync(entry)
+
+        # Verify success without downloading
+        assert result is True
+        assert entry.stats_json_file_path().read_bytes() == json_content
+        assert entry.data_parquet_file_path().read_bytes() == parquet_content
+
+    def test_download_if_sha256_mismatch(self, tmp_path):
+        """Ensure that we download on sha256 mismatch."""
+        json_content = b'{"test": "data"}'
+        parquet_content = b"PARQUET_DATA"
+        json_sha256 = _compute_test_sha256(json_content)
+        parquet_sha256 = _compute_test_sha256(parquet_content)
+
+        entry = self._create_mock_entry(tmp_path)
+
+        # Pre-create files with WRONG content
+        entry.stats_json_file_path().write_bytes(b"wrong content")
+        entry.data_parquet_file_path().write_bytes(b"wrong parquet")
+
+        manifest = Manifest(
+            v=0,
+            files={
+                "data.parquet": FileEntry(
+                    sha256=parquet_sha256, url="https://example.com/data.parquet"
+                ),
+                "stats.json": FileEntry(sha256=json_sha256, url="https://example.com/stats.json"),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        mock_urlopen = self._mock_urlopen_with_content(json_content, parquet_content)
+
+        with patch("iqb.ghremote.cache.urlopen", side_effect=mock_urlopen):
+            result = cache.sync(entry)
+
+        # Verify files were re-downloaded with correct content
+        assert result is True
+        assert entry.stats_json_file_path().read_bytes() == json_content
+        assert entry.data_parquet_file_path().read_bytes() == parquet_content
+
+    def test_sync_success_both_files(self, tmp_path, caplog):
+        """Ensure that both JSON and parquet files are synced successfully."""
+        json_content = b'{"test": "data"}'
+        parquet_content = b"PARQUET_DATA"
+        json_sha256 = _compute_test_sha256(json_content)
+        parquet_sha256 = _compute_test_sha256(parquet_content)
+
+        entry = self._create_mock_entry(tmp_path)
+
+        manifest = Manifest(
+            v=0,
+            files={
+                "data.parquet": FileEntry(
+                    sha256=parquet_sha256, url="https://example.com/data.parquet"
+                ),
+                "stats.json": FileEntry(sha256=json_sha256, url="https://example.com/stats.json"),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        mock_urlopen = self._mock_urlopen_with_content(json_content, parquet_content)
+
+        with (
+            patch("iqb.ghremote.cache.urlopen", side_effect=mock_urlopen),
+            caplog.at_level(logging.INFO),
+        ):
+            result = cache.sync(entry)
+
+        # Verify success
+        assert result is True
+        assert entry.stats_json_file_path().exists()
+        assert entry.data_parquet_file_path().exists()
+        # Verify logging shows both files were fetched
+        assert "fetching" in caplog.text
+        assert "validating" in caplog.text
+        assert "syncing" in caplog.text
+
+    def test_download_failure(self, tmp_path, caplog):
+        """Ensure that we return False when download fails (network error, 404, etc)."""
+        entry = self._create_mock_entry(tmp_path)
+
+        manifest = Manifest(
+            v=0,
+            files={
+                "data.parquet": FileEntry(sha256="abc123", url="https://example.com/data.parquet"),
+                "stats.json": FileEntry(sha256="def456", url="https://example.com/stats.json"),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        # Mock urlopen to raise URLError
+        with (
+            patch("iqb.ghremote.cache.urlopen", side_effect=URLError("Network error")),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = cache.sync(entry)
+
+        assert result is False
+        assert "failure" in caplog.text
+
+    def test_sha256_mismatch_after_download(self, tmp_path, caplog):
+        """Ensure that we return False and delete file when SHA256 validation fails."""
+        json_content = b'{"test": "data"}'
+        parquet_content = b"PARQUET_DATA"
+        # Use WRONG sha256 in manifest
+        wrong_sha256 = "0" * 64
+
+        entry = self._create_mock_entry(tmp_path)
+
+        manifest = Manifest(
+            v=0,
+            files={
+                "data.parquet": FileEntry(
+                    sha256=wrong_sha256, url="https://example.com/data.parquet"
+                ),
+                "stats.json": FileEntry(sha256=wrong_sha256, url="https://example.com/stats.json"),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        mock_urlopen = self._mock_urlopen_with_content(json_content, parquet_content)
+
+        with (
+            patch("iqb.ghremote.cache.urlopen", side_effect=mock_urlopen),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = cache.sync(entry)
+
+        # Verify failure and files are deleted
+        assert result is False
+        assert "SHA256 mismatch" in caplog.text
+        # Files should be deleted after failed validation
+        assert not entry.stats_json_file_path().exists()
+
+    def test_creates_parent_directories(self, tmp_path):
+        """Ensure that parent directories are created when they don't exist."""
+        json_content = b'{"test": "data"}'
+        parquet_content = b"PARQUET_DATA"
+        json_sha256 = _compute_test_sha256(json_content)
+        parquet_sha256 = _compute_test_sha256(parquet_content)
+
+        # Create entry with nested paths that don't exist yet
+        entry = Mock()
+        entry.data_dir = tmp_path
+        entry.data_parquet_file_path.return_value = tmp_path / "nested" / "dir" / "data.parquet"
+        entry.stats_json_file_path.return_value = tmp_path / "nested" / "dir" / "stats.json"
+
+        manifest = Manifest(
+            v=0,
+            files={
+                "nested/dir/data.parquet": FileEntry(
+                    sha256=parquet_sha256, url="https://example.com/data.parquet"
+                ),
+                "nested/dir/stats.json": FileEntry(
+                    sha256=json_sha256, url="https://example.com/stats.json"
+                ),
+            },
+        )
+        cache = IQBGitHubRemoteCache(manifest)
+
+        mock_urlopen = self._mock_urlopen_with_content(json_content, parquet_content)
+
+        # Verify parent directories don't exist yet
+        assert not entry.data_parquet_file_path().parent.exists()
+
+        with patch("iqb.ghremote.cache.urlopen", side_effect=mock_urlopen):
+            result = cache.sync(entry)
+
+        # Verify success and directories were created
+        assert result is True
+        assert entry.stats_json_file_path().exists()
+        assert entry.data_parquet_file_path().exists()
+        assert entry.data_parquet_file_path().parent.exists()

--- a/library/tests/iqb/pipeline/bqpq_test.py
+++ b/library/tests/iqb/pipeline/bqpq_test.py
@@ -114,6 +114,7 @@ class TestPipelineBQPQQueryResultSaveDataParquet:
 
             # Create a side effect to actually create the data.parquet file
             def create_parquet_file(*args, **kwargs):
+                _, _ = args, kwargs
                 cache_dir.mkdir(parents=True, exist_ok=True)
                 (cache_dir / "data.parquet").write_text("fake data")
 
@@ -153,6 +154,7 @@ class TestPipelineBQPQQueryResultSaveDataParquet:
 
             # Create a side effect to actually create the data.parquet file
             def create_parquet_file(*args, **kwargs):
+                _, _ = args, kwargs
                 cache_dir.mkdir(parents=True, exist_ok=True)
                 (cache_dir / "data.parquet").write_text("")
 
@@ -206,6 +208,7 @@ class TestPipelineBQPQQueryResultSaveDataParquet:
 
             # Create a side effect to actually create the data.parquet file
             def create_parquet_file(*args, **kwargs):
+                _, _ = args, kwargs
                 cache_dir.mkdir(parents=True, exist_ok=True)
                 (cache_dir / "data.parquet").write_text("fake data")
 
@@ -244,6 +247,7 @@ class TestPipelineBQPQQueryResultSaveDataParquet:
 
             # Create a side effect to actually create the data.parquet file
             def create_parquet_file(*args, **kwargs):
+                _, _ = args, kwargs
                 cache_dir.mkdir(parents=True, exist_ok=True)
                 (cache_dir / "data.parquet").write_text("fake data")
 

--- a/library/tests/iqb/pipeline/pipeline_test.py
+++ b/library/tests/iqb/pipeline/pipeline_test.py
@@ -378,6 +378,7 @@ class TestIQBPipelineGetCacheEntry:
 
             def sync(self, entry: PipelineCacheEntry) -> bool:
                 """Simulate successful remote cache sync."""
+                _ = entry
                 self.sync_called = True
                 # Create the files that remote cache would download
                 expected_cache_dir.mkdir(parents=True, exist_ok=True)
@@ -431,6 +432,7 @@ class TestIQBPipelineGetCacheEntry:
 
             def sync(self, entry: PipelineCacheEntry) -> bool:
                 """Simulate remote cache sync failure."""
+                _ = entry
                 self.sync_called = True
                 return False  # Sync failed
 

--- a/uv.lock
+++ b/uv.lock
@@ -445,6 +445,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dacite"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/a0/7ca79796e799a3e782045d29bf052b5cde7439a2bbb17f15ff44f7aacc63/dacite-1.9.2.tar.gz", hash = "sha256:6ccc3b299727c7aa17582f0021f6ae14d5de47c7227932c47fec4cdfefd26f09", size = 22420, upload-time = "2025-02-05T09:27:29.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/35/386550fd60316d1e37eccdda609b074113298f23cef5bddb2049823fe666/dacite-1.9.2-py3-none-any.whl", hash = "sha256:053f7c3f5128ca2e9aceb66892b1a3c8936d02c686e707bee96e19deef4bc4a0", size = 16600, upload-time = "2025-02-05T09:27:24.345Z" },
+]
+
+[[package]]
 name = "db-dtypes"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1443,6 +1452,7 @@ name = "mlab-iqb"
 version = "0.1.0"
 source = { editable = "library" }
 dependencies = [
+    { name = "dacite" },
     { name = "db-dtypes" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-bigquery-storage" },
@@ -1460,6 +1470,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dacite", specifier = ">=1.9.2" },
     { name = "db-dtypes", specifier = ">=1.0.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.0.0" },
     { name = "google-cloud-bigquery-storage", specifier = ">=2.0.0" },


### PR DESCRIPTION
The `ghremote` package implements `pipeline.RemoteCache` using GitHub releases to publish files. The `pipeline.RemoteCache` facility was introduced in https://github.com/m-lab/iqb/pull/85. The implementation is at `ghremote.IQBGitHubRemoteCache`. We derived the implementation from already-existing code living inside the `./data/ghcache.py` file. We're also adding `dacite` as a dependency, to easily convert parsed JSONs to dataclasses.

Using GitHub releases to publish datasets is meant as an interim solution. However, we are also going to implement a better approach for datasets, possibly based on GCS buckets. To this end, we need to refactor the existing approach to create the facilities for making the GCS-based approach possible. Hence, this diff.

This diff adds the basic functionality and tests, along with minor changes and tweaks in the rest of the codebase (boyscout rule). We integrated the code added by this PR and verified it is working as intended in https://github.com/m-lab/iqb/pull/87.