### PR TITLE
feat(pipeline)!: introduce file-based locking

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "db-dtypes>=1.0.0",
     "python-dateutil>=2.9.0.post0",
     "dacite>=1.9.2",
+    "filelock>=3.20.1",
 ]
 
 [project.urls]

--- a/library/src/iqb/pipeline/__init__.py
+++ b/library/src/iqb/pipeline/__init__.py
@@ -8,6 +8,16 @@ within the `iqb` library`, allows to read/write query entries.
 The `iqb_dataset_name_for_{project}` family of functions allow to
 derive the correct dataset name for a given project.
 
+The `PipelineCacheEntry` class is a lazy cache entry whose files
+you can safely obtain using the `.sync` method, provided that mechanisms
+to obtain them are configured (e.g., the remote_cache argument for
+`PipelineCacheManager` and/or `IQBPipeline` and the billing BigQuery
+project for `IQBPipeline`).
+
+The `PipelineCacheEntry.lock()` method allows to lock a specific
+entry in exclusive mode to avoid concurrency issues. To implement
+this feature we use advisory file locking (e.g., `flock`).
+
 The `iqb_parquet_read` function allows to efficiently read and
 filter data inside an arbitrary parquet file.
 

--- a/library/tests/iqb/cache/mlab_test.py
+++ b/library/tests/iqb/cache/mlab_test.py
@@ -214,6 +214,32 @@ class TestMLabCacheReaderIntegration:
         assert data["latency_ms"] == 0.806
         assert data["packet_loss"] == 0.0
 
+    def test_download_stats_property(self, data_dir):
+        """Test backward compatibility property download_stats."""
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        # Use the backward compatibility property
+        stats_path = entry.download_stats
+
+        # Verify it returns the correct path
+        assert stats_path == entry.download.stats_json_file_path()
+        assert stats_path.exists()
+        assert stats_path.name == "stats.json"
+
+    def test_upload_stats_property(self, data_dir):
+        """Test backward compatibility property upload_stats."""
+        reader = _create_reader(data_dir)
+        entry = _get_country_cache_entry_2024_10(reader)
+
+        # Use the backward compatibility property
+        stats_path = entry.upload_stats
+
+        # Verify it returns the correct path
+        assert stats_path == entry.upload.stats_json_file_path()
+        assert stats_path.exists()
+        assert stats_path.name == "stats.json"
+
 
 class TestMLabDataFramePairExceptions:
     def test_download_multiple_rows_raises(self):

--- a/uv.lock
+++ b/uv.lock
@@ -522,6 +522,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.20.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/23/ce7a1126827cedeb958fc043d61745754464eb56c5937c35bbf2b8e26f34/filelock-3.20.1.tar.gz", hash = "sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c", size = 19476, upload-time = "2025-12-15T23:54:28.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/7f/a1a97644e39e7316d850784c642093c99df1290a460df4ede27659056834/filelock-3.20.1-py3-none-any.whl", hash = "sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a", size = 16666, upload-time = "2025-12-15T23:54:26.874Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.60.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1454,6 +1463,7 @@ source = { editable = "library" }
 dependencies = [
     { name = "dacite" },
     { name = "db-dtypes" },
+    { name = "filelock" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-bigquery-storage" },
     { name = "pandas" },
@@ -1472,6 +1482,7 @@ dev = [
 requires-dist = [
     { name = "dacite", specifier = ">=1.9.2" },
     { name = "db-dtypes", specifier = ">=1.0.0" },
+    { name = "filelock", specifier = ">=3.20.1" },
     { name = "google-cloud-bigquery", specifier = ">=3.0.0" },
     { name = "google-cloud-bigquery-storage", specifier = ">=2.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },


### PR DESCRIPTION
We need to improve our concurrency story, especially considering that the code may run in a service that may fetch new data. The first step to ensure safety (implemented by this diff) is implementing mutual exclusion when writing. To this end, we use portable, advisory file locking.

While working on this diff, I also realized that part of the `pipeline` code (and namely `PipelineCacheManager`) is lazy and part (`IQBPipeline`) is not lazy with `fetch_if_missing`. This design makes it problematic to fit a single locking schema into the model. So, we remove the non-lazy part and expose to the user the ability to `lock()` and `sync()` a `PipelineCacheEntry`. This means that the user can also decide to avoid locking, which makes sense when one is using this library for research.

While there, also expose `PipelineCacheEntry.exists()` so we don't need to roll out manually code that checks for the existence of both files, and which is more robust in case we add files to an entry.

BREAKING CHANGE: the `fetch_if_missing` argument has been removed and now you need to call `.sync()` explicitly to sync.