### PR TITLE
feat(iqb): export remote-github-cache names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Python tooling
+- Always use `uv` for Python commands (e.g., `uv run pytest`, `uv run python`).
+- Do not call `python`, `pip`, or `pytest` directly unless explicitly requested.
+
+## Repo orientation
+- Library code: `library/src/iqb`
+- Tests: `library/tests`
+- Cached fixtures: `library/tests/fixtures`
+- See `README.md` for architecture and usage details
+- See `library/README.md` for testing workflows and examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Follow the repository instructions in [AGENTS.md](AGENTS.md).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+Follow the repository instructions in [AGENTS.md](AGENTS.md).

--- a/library/src/iqb/__init__.py
+++ b/library/src/iqb/__init__.py
@@ -7,6 +7,7 @@ network measurement data, weight matrices, and quality thresholds.
 from .cache import IQBCache
 from .calculator import IQBCalculator
 from .config import IQB_CONFIG
+from .ghremote import IQBGitHubRemoteCache, iqb_github_load_manifest
 from .pipeline import (
     IQBDatasetGranularity,
     IQBDatasetMLabTable,
@@ -22,9 +23,11 @@ __all__ = [
     "IQBCalculator",
     "IQBCache",
     "IQB_CONFIG",
+    "IQBGitHubRemoteCache",
     "IQBPipeline",
     "IQBDatasetGranularity",
     "IQBDatasetMLabTable",
+    "iqb_github_load_manifest",
     "iqb_dataset_name_for_mlab",
 ]
 __version__ = "0.4.0"


### PR DESCRIPTION
This pull request exports the remote-github-cache related names so they can be used directly from inside notebooks etc.

While there, add basic AI-assistants instructions.