### PR TITLE
fix(pipeline): make BQ idempotent by default

### DIFF
--- a/library/src/iqb/pipeline/pipeline.py
+++ b/library/src/iqb/pipeline/pipeline.py
@@ -119,8 +119,10 @@ class IQBPipeline:
 
     def _bq_syncer(self, entry: PipelineCacheEntry) -> bool:
         """Internal method to get the entry files using a BigQuery query."""
+        if entry.exists():
+            log.info("querying for %s... skipped (cached)", entry)
+            return True
         try:
-            # TODO(bassosimone): consider skipping the query when entry.exists() is True.
             log.info("querying for %s... start", entry)
             result = self._execute_query_template(entry)
             result.save_data_parquet()


### PR DESCRIPTION
BigQuery is slow and costly, so we do not want to re-run queries when we already have local files.

In the future, we may introduce logic to conditionally re-run the query but certainly this is the right™ default.