### PR TITLE
fix!: enforce keyword arguments

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -69,6 +69,12 @@ pipeline = IQBPipeline(
 
 You can then use `pipeline` to run queries up to a daily quota.
 
+## Coding Style
+
+We strongly prefer keyword-only arguments for public constructors (e.g.,
+`IQBPipeline`, `IQBCache`) and functions, because they are harder to misuse
+and they enable incremental refactoring.
+
 ## Running Tests
 
 The library uses `pytest` for testing. Tests are located in the `tests/`

--- a/library/src/iqb/cache/cache.py
+++ b/library/src/iqb/cache/cache.py
@@ -12,7 +12,7 @@ from ..pipeline.pipeline import PipelineCacheManager, PipelineRemoteCache
 from .mlab import IQBDataMLab, MLabCacheEntry, MLabCacheManager
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class CacheEntry:
     """
     Cached data for computing IQB scores.
@@ -26,7 +26,7 @@ class CacheEntry:
     mlab: MLabCacheEntry
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class IQBData:
     """
     Data for computing the IQB score.
@@ -43,6 +43,7 @@ class IQBCache:
 
     def __init__(
         self,
+        *,
         data_dir: str | Path | None = None,
         remote_cache: PipelineRemoteCache | None = None,
     ):

--- a/library/src/iqb/cache/mlab.py
+++ b/library/src/iqb/cache/mlab.py
@@ -15,7 +15,7 @@ from ..pipeline.dataset import IQBDatasetMLabTable
 from ..pipeline.pipeline import PipelineCacheManager
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class IQBDataMLab:
     """
     Contains M-Lab data for computing the IQB score.
@@ -42,7 +42,7 @@ class IQBDataMLab:
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MLabDataFramePair:
     """
     Pair of DataFrames containing M-Lab measurement data.
@@ -117,7 +117,7 @@ class MLabDataFramePair:
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MLabCacheEntry:
     """
     M-Lab entry inside the data cache.

--- a/library/src/iqb/ghremote/cache.py
+++ b/library/src/iqb/ghremote/cache.py
@@ -19,7 +19,7 @@ from ..pipeline.cache import PipelineCacheEntry
 log = logging.getLogger("ghremote/cache")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class FileEntry:
     """Entry in the manifest for a single cached file."""
 
@@ -27,7 +27,7 @@ class FileEntry:
     url: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Manifest:
     """Manifest for cached files stored in GitHub releases."""
 

--- a/library/src/iqb/pipeline/bqpq.py
+++ b/library/src/iqb/pipeline/bqpq.py
@@ -38,7 +38,7 @@ class PipelineBQPQPathsProvider(Protocol):
     def stats_json_file_path(self) -> Path: ...
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PipelineBQPQQueryResult:
     """
     Result of the query with reference to job and row iterator.

--- a/library/src/iqb/pipeline/cache.py
+++ b/library/src/iqb/pipeline/cache.py
@@ -21,7 +21,7 @@ class PipelineEntrySyncError(RuntimeError):
     """Error emitted when we cannot sync the entry."""
 
 
-@dataclass
+@dataclass(kw_only=True)
 class PipelineCacheEntry:
     """
     Reference to a cache entry containing query results and metadata.

--- a/library/src/iqb/pipeline/pipeline.py
+++ b/library/src/iqb/pipeline/pipeline.py
@@ -25,6 +25,7 @@ class IQBPipeline:
 
     def __init__(
         self,
+        *,
         project: str,
         data_dir: str | Path | None = None,
         remote_cache: PipelineRemoteCache | None = None,


### PR DESCRIPTION
This diff enforces keyword arguments in most places. This style of encoding arguments is robust to incremental refactoring and allows to write more flexible APIs with less breakages.