### PR TITLE
fix(ghremote)!: more cohesive construction

### DIFF
--- a/library/src/iqb/__init__.py
+++ b/library/src/iqb/__init__.py
@@ -7,7 +7,7 @@ network measurement data, weight matrices, and quality thresholds.
 from .cache import IQBCache
 from .calculator import IQBCalculator
 from .config import IQB_CONFIG
-from .ghremote import IQBGitHubRemoteCache, iqb_github_load_manifest
+from .ghremote import IQBGitHubRemoteCache
 from .pipeline import (
     IQBDatasetGranularity,
     IQBDatasetMLabTable,
@@ -32,7 +32,6 @@ __all__ = [
     "IQBPipeline",
     "IQBDatasetGranularity",
     "IQBDatasetMLabTable",
-    "iqb_github_load_manifest",
     "iqb_dataset_name_for_mlab",
     "__version__",
 ]

--- a/library/src/iqb/ghremote/__init__.py
+++ b/library/src/iqb/ghremote/__init__.py
@@ -15,14 +15,16 @@ Manifest format:
     }
   }
 }
+
+The manifest is expected at:
+
+    $datadir/state/ghremote/manifest.json
+
+Where $datadir defaults to `.iqb` in the current working directory.
 """
 
-from .cache import (
-    IQBGitHubRemoteCache,
-    iqb_github_load_manifest,
-)
+from .cache import IQBGitHubRemoteCache
 
 __all__ = [
     "IQBGitHubRemoteCache",
-    "iqb_github_load_manifest",
 ]


### PR DESCRIPTION
This diff refactors `iqb.ghremote` so that its construction mirrors the pattern used for `iqb.cache` and `iqb.pipeline.

This change makes construction more cohesive and simple.

BREAKING CHANGE: removed `iqb_github_load_manifest` and change parameters passed to `IQBGitHubRemoteCache`. However, these two types weren't ever released, so the impact is ~zero.