### PR TITLE
fix(pipeline): prevent start_date == end_date

### DIFF
--- a/library/src/iqb/pipeline/cache.py
+++ b/library/src/iqb/pipeline/cache.py
@@ -174,11 +174,11 @@ def data_dir_or_default(data_dir: str | Path | None) -> Path:
 
 
 def _parse_both_dates(start_date: str, end_date: str) -> tuple[datetime, datetime]:
-    """Parses both dates and ensures start_date <= end_date."""
+    """Parses both dates and ensures start_date < end_date."""
     start_time = _parse_date(start_date)
     end_time = _parse_date(end_date)
-    if start_time > end_time:
-        raise ValueError(f"start_date must be <= end_date, got: {start_date} > {end_date}")
+    if start_time >= end_time:
+        raise ValueError(f"start_date must be < end_date, got: {start_date} >= {end_date}")
     return start_time, end_time
 
 

--- a/library/tests/iqb/pipeline/cache_test.py
+++ b/library/tests/iqb/pipeline/cache_test.py
@@ -68,14 +68,13 @@ class TestParseBothDates:
         assert end == datetime(2024, 11, 1)
 
     def test_parse_equal_dates(self):
-        """Test parsing when start equals end (valid for zero-duration queries)."""
-        start, end = _parse_both_dates("2024-10-01", "2024-10-01")
-        assert start == datetime(2024, 10, 1)
-        assert end == datetime(2024, 10, 1)
+        """Test error when start_date == end_date."""
+        with pytest.raises(ValueError, match="start_date must be < end_date"):
+            _parse_both_dates("2024-10-01", "2024-10-01")
 
     def test_parse_reversed_dates_error(self):
         """Test error when start_date > end_date."""
-        with pytest.raises(ValueError, match="start_date must be <= end_date"):
+        with pytest.raises(ValueError, match="start_date must be < end_date"):
             _parse_both_dates("2024-11-01", "2024-10-01")
 
     def test_parse_invalid_start_date(self):
@@ -203,7 +202,7 @@ class TestPipelineCacheManager:
         """Test that get_cache_entry validates date range."""
         manager = PipelineCacheManager(data_dir=tmp_path)
 
-        with pytest.raises(ValueError, match="start_date must be <= end_date"):
+        with pytest.raises(ValueError, match="start_date must be < end_date"):
             manager.get_cache_entry(
                 dataset_name="downloads_by_country",
                 start_date="2024-11-01",

--- a/library/tests/iqb/pipeline/pipeline_test.py
+++ b/library/tests/iqb/pipeline/pipeline_test.py
@@ -126,7 +126,7 @@ class TestIQBPipelineExecuteQuery:
         mock_client.assert_called_once_with(project="test-project")
 
         # Ensure we get the expected exception
-        with pytest.raises(ValueError, match="start_date must be <= end_date"):
+        with pytest.raises(ValueError, match="start_date must be < end_date"):
             pipeline.execute_query_template(
                 dataset_name="downloads_by_country",
                 start_date="2024-11-01",
@@ -348,7 +348,7 @@ class TestIQBPipelineGetCacheEntry:
             )
 
         # Invalid date range should fail immediately
-        with pytest.raises(ValueError, match="start_date must be <= end_date"):
+        with pytest.raises(ValueError, match="start_date must be < end_date"):
             pipeline.get_cache_entry(
                 dataset_name="downloads_by_country",
                 start_date="2024-11-01",


### PR DESCRIPTION
This condition will cause a BigQuery query to run, which reduces the usage quota, for no reason.