### PR TITLE
ghcache.py!: remove sync and update manifest path

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -2,14 +2,6 @@
 
 This directory contains static reference data used by the IQB prototype.
 
-## Current Dataset
-
-**Period**: October 2024 and October 2025
-
-**Source**: [M-Lab NDT](https://www.measurementlab.net/tests/ndt/) unified views
-
-**Countries**: All available countries
-
 ## Data Format
 
 Raw query results stored efficiently for flexible analysis:
@@ -27,57 +19,34 @@ Raw query results stored efficiently for flexible analysis:
 Since the v1 Parquet files can be large (~1-60 MiB) and we have BigQuery quota
 constraints, we use GitHub releases to distribute pre-generated cache files.
 
-### For Data Scientists (Manual Workflow)
+The `generate_data.py` script automatically syncs cached files to avoid running
+potentially expensive BigQuery queries.
 
-Sync cached files from GitHub before analysis:
-
-```bash
-cd data/
-./ghcache.py sync
-```
-
-This downloads any missing cache files listed in `ghcache.json` and verifies SHA256.
-
-### For Pipeline Users (Automatic)
-
-The `generate_data.py` script automatically syncs cached files before running queries,
-so you don't need to run `ghcache.py` manually.
+The GitHub release manifest lives at `state/ghremote/manifest.json`.
 
 ### For Maintainers (Publishing New Cache)
 
 When you generate new cache files locally:
 
 ```bash
-cd data/
-./ghcache.py scan
+uv run ./data/ghcache.py scan
 ```
 
 This:
 1. Scans `cache/v1/` for git-ignored files
 2. Computes SHA256 hashes
 3. Copies files to `data/` with mangled names (ready for upload)
-4. Updates `ghcache.json` manifest
+4. Updates `state/ghremote/manifest.json` manifest
 
 Then manually:
 1. Upload mangled files to GitHub release (e.g., v0.1.0)
-2. Commit updated `ghcache.json` to repository
-
-**Note**: This system assumes Unix paths and won't work on Windows.
-
-## How This Data Was Generated
-
-### BigQuery Queries
-
-The data was extracted from M-Lab's public BigQuery tables using queries
-inside the [../library/src/iqb/queries](../library/src/iqb/queries) package.
+2. Commit updated `state/ghremote/manifest.json` to repository
 
 ### Running the Data Generation Pipeline
 
 **Prerequisites**:
 
 - Google Cloud SDK (`gcloud`) installed
-
-- BigQuery CLI (`bq`) installed
 
 - `gcloud`-authenticated with an account subscribed to
 [M-Lab Discuss mailing list](https://groups.google.com/a/measurementlab.net/g/discuss)
@@ -87,17 +56,16 @@ inside the [../library/src/iqb/queries](../library/src/iqb/queries) package.
 **Complete Pipeline** (recommended):
 
 ```bash
-cd data/
-uv run python generate_data.py
+uv run python ./data/generate_data.py
 ```
 
 This orchestrates the complete pipeline:
 
-1. Queries BigQuery for multiple datasets (country, country_asn, country_city, country_city_asn, country_subdivision1)
+1. Queries BigQuery for multiple geographical granularities (country, country_asn, etc.)
 
 2. Queries both download and upload metrics for each dataset
 
-3. Saves results to v1 Parquet cache with query metadata (skips JSON conversion for performance)
+3. Saves results to v1 Parquet cache with query metadata
 
 Generated files: v1 Parquet files in `./cache/v1/` with query metadata.
 
@@ -107,7 +75,7 @@ Generated files: v1 Parquet files in `./cache/v1/` with query metadata.
 cd data/
 
 # Run a single query
-uv run python run_query.py downloads_by_country \
+uv run python run_query.py --granularity country \
   --start-date 2024-10-01 --end-date 2024-11-01
 
 # Inspect results with pandas
@@ -126,47 +94,9 @@ EOF
 - [run_query.py](run_query.py) - Executes BigQuery queries using IQBPipeline,
 saves v1 Parquet cache only (use pandas to inspect results)
 
-## Notes
-
-- **Cache format**: v1 Parquet files (~1-60 MiB) with stats.json for efficient
-processing and cost tracking.
-
-- **Time granularity**: Data is aggregated over the entire
-months of October 2024 and October 2025. The analyst decides which
-time window to use for running IQB calculations.
-
-- **Percentile selection**: The Streamlit UI allows users
-to select which percentile(s) to use for IQB score calculations.
-
-- **Query results**: Raw query results are stored in Parquet format for efficient
-filtering and analysis. Use the [../library](../library) `IQBCache` to access them.
-
-## M-Lab NDT Data Schema
-
-M-Lab provides two unified views:
-
-- `measurement-lab.ndt.unified_downloads` - Download tests
-
-- `measurement-lab.ndt.unified_uploads` - Upload tests
-
-Key fields used:
-
-- `a.MeanThroughputMbps` - Mean throughput in Mbps
-
-- `a.MinRTT` - Minimum round-trip time in milliseconds
-
-- `a.LossRate` - Packet loss rate (0.0-1.0)
-
-- `client.Geo.CountryCode` - ISO country code
-
-- `date` - Measurement date (YYYY-MM-DD)
-
-See [M-Lab NDT documentation](https://www.measurementlab.net/tests/ndt/#ndt-data-in-bigquery)
-for details.
+- [ghcache.py](ghcache.py) - Utility to manage the GitHub interim cache.
 
 ## Future Improvements (Phase 2+)
 
-- Finer geographic resolution (cities, provinces, ASNs) - IN PROGRESS
 - Replace GitHub releases with GCS buckets for cache distribution
 - Additional datasets (Ookla, Cloudflare)
-- Finer time granularity (daily, weekly)


### PR DESCRIPTION
This diff removes the `ghcache.py sync` functionality, which is now obsolete, and updates the `manifest.json` file path so that `ghcache.py scan` (which was broken by the previous commit) works again.

The `ghcache.py` script, right now, is basically just an interim solution to manage publishing at GitHub given that fetching from the GitHub cache is now integrated in the core library.

While there, make sure that this code can work on Windows by normalizing file paths to the Unix convention.

While there, maintain the documentation, remove obsolete information and update the rest.

BREAKING CHANGE: remove `ghcache.py sync` subcommand, whose code has been evolved, refactored, and integrated into the IQB package as the `iqb.ghremote` sub-package.