### PR TITLE
feat(cli): implement `iqb cache pull`

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "filelock>=3.20.1",
     "rich>=14.2.0",
     "click>=8.1.0",
+    "requests>=2.28.0",
 ]
 
 [project.urls]

--- a/library/src/iqb/cli/__init__.py
+++ b/library/src/iqb/cli/__init__.py
@@ -33,4 +33,5 @@ def version_cmd() -> None:
 
 # Register subcommands (must be after cli is defined)
 from . import cache as _cache  # noqa: E402, F401
+from . import cache_pull as _cache_pull  # noqa: E402, F401
 from . import cache_status as _cache_status  # noqa: E402, F401

--- a/library/src/iqb/cli/cache_pull.py
+++ b/library/src/iqb/cli/cache_pull.py
@@ -1,0 +1,122 @@
+"""Cache pull command."""
+
+import hashlib
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import click
+import requests
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    TextColumn,
+    TransferSpeedColumn,
+)
+
+from ..ghremote import DiffState, diff, load_manifest, manifest_path_for_data_dir
+from ..ghremote.diff import DiffEntry
+from ..pipeline.cache import data_dir_or_default
+from .cache import cache
+
+
+def _short_name(file: str) -> str:
+    """Extract a short display name from a cache path."""
+    parts = file.split("/")
+    return "/".join(parts[-2:]) if len(parts) >= 2 else file
+
+
+def _download_one(
+    entry: DiffEntry,
+    data_dir: Path,
+    session: requests.Session,
+    progress: Progress,
+) -> str:
+    """Download a single file, verify SHA256, atomic-replace. Returns the file path."""
+    assert entry.url is not None
+    assert entry.remote_sha256 is not None
+    dest = data_dir / entry.file
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    task_id = progress.add_task(_short_name(entry.file), total=None)
+    try:
+        with TemporaryDirectory(dir=dest.parent) as tmp_dir:
+            tmp_file = Path(tmp_dir) / dest.name
+            resp = session.get(entry.url, stream=True)
+            resp.raise_for_status()
+            content_length = resp.headers.get("Content-Length")
+            if content_length is not None:
+                progress.update(task_id, total=int(content_length))
+            sha256 = hashlib.sha256()
+            with open(tmp_file, "wb") as fp:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    fp.write(chunk)
+                    sha256.update(chunk)
+                    progress.update(task_id, advance=len(chunk))
+            got = sha256.hexdigest()
+            if got != entry.remote_sha256:
+                raise ValueError(
+                    f"SHA256 mismatch for {entry.file}: expected {entry.remote_sha256}, got {got}"
+                )
+            os.replace(tmp_file, dest)
+    finally:
+        progress.remove_task(task_id)
+    return entry.file
+
+
+@cache.command()
+@click.option("-d", "--dir", "data_dir", default=None, help="Data directory (default: .iqb)")
+@click.option("-f", "--force", is_flag=True, help="Re-download files with mismatched hashes")
+@click.option("-j", "--jobs", default=8, show_default=True, help="Number of parallel downloads")
+def pull(data_dir: str | None, force: bool, jobs: int) -> None:
+    """Download missing cache files from the manifest."""
+    resolved = data_dir_or_default(data_dir)
+    manifest_path = manifest_path_for_data_dir(resolved)
+    manifest = load_manifest(manifest_path)
+
+    # Collect entries to download
+    targets: list[DiffEntry] = []
+    for entry in diff(manifest, resolved):
+        if entry.state == DiffState.ONLY_REMOTE:
+            targets.append(entry)
+        elif entry.state == DiffState.SHA256_MISMATCH and force:
+            targets.append(entry)
+
+    if not targets:
+        click.echo("Nothing to download.")
+        return
+
+    session = requests.Session()
+    failed: list[tuple[str, str]] = []
+    t0 = time.monotonic()
+    with (
+        Progress(
+            TextColumn("{task.description}"),
+            BarColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+        ) as progress,
+        ThreadPoolExecutor(max_workers=jobs) as pool,
+    ):
+        futures = {
+            pool.submit(_download_one, entry, resolved, session, progress): entry
+            for entry in targets
+        }
+        for future in as_completed(futures):
+            entry = futures[future]
+            try:
+                future.result()
+            except Exception as exc:
+                failed.append((entry.file, str(exc)))
+    elapsed = time.monotonic() - t0
+
+    ok = len(targets) - len(failed)
+    click.echo(f"Downloaded {ok}/{len(targets)} file(s) in {elapsed:.1f}s.")
+
+    if failed:
+        click.echo(f"{len(failed)} download(s) failed:", err=True)
+        for file, reason in failed:
+            click.echo(f"  {file}: {reason}", err=True)
+        raise SystemExit(1)

--- a/library/src/iqb/ghremote/cache.py
+++ b/library/src/iqb/ghremote/cache.py
@@ -141,6 +141,8 @@ class IQBRemoteCache:
         _sync_file_entry(parquet_entry, entry.data_parquet_file_path())
 
 
+# TODO(bassosimone): this download logic overlaps with cli/cache_pull.py;
+# consider unifying into a shared helper once both implementations stabilise.
 def _sync_file_entry(entry: FileEntry, dest_path: Path):
     """Sync the given FileEntry with the remotely cached file."""
     # Determine whether we need to download again

--- a/library/tests/iqb/cli/cache_pull_test.py
+++ b/library/tests/iqb/cli/cache_pull_test.py
@@ -1,0 +1,245 @@
+"""Tests for the iqb.cli.cache_pull module."""
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from iqb.cli import cli
+
+
+def _sha256(content: bytes) -> str:
+    """Compute SHA256 hex digest for test data."""
+    return hashlib.sha256(content).hexdigest()
+
+
+def _write_manifest(data_dir: Path, files: dict[str, dict[str, str]]) -> None:
+    """Write a manifest.json under the standard state directory."""
+    manifest_path = data_dir / "state" / "ghremote" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps({"v": 0, "files": files}))
+
+
+def _make_cache_file(data_dir: Path, rel_path: str, content: bytes) -> Path:
+    """Create a file under data_dir at the given relative path."""
+    full = data_dir / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_bytes(content)
+    return full
+
+
+_TS1 = "20241001T000000Z"
+_TS2 = "20241101T000000Z"
+_FILE_A = f"cache/v1/{_TS1}/{_TS2}/downloads/data.parquet"
+_FILE_B = f"cache/v1/{_TS1}/{_TS2}/uploads/data.parquet"
+
+
+def _fake_response(content: bytes) -> MagicMock:
+    """Create a mock response that yields content in chunks."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.headers = {"Content-Length": str(len(content))}
+    resp.iter_content = MagicMock(return_value=iter([content]))
+    return resp
+
+
+class TestCachePullEmptyManifest:
+    """Empty manifest produces 'Nothing to download.'."""
+
+    def test_nothing_to_download(self, tmp_path: Path):
+        _write_manifest(tmp_path, {})
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "Nothing to download" in result.output
+
+
+class TestCachePullOnlyRemote:
+    """ONLY_REMOTE entries are downloaded."""
+
+    @patch("iqb.cli.cache_pull.requests.Session")
+    def test_downloads_only_remote(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content = b"remote file content"
+        sha = _sha256(content)
+        url = "https://example.com/a"
+        _write_manifest(tmp_path, {_FILE_A: {"sha256": sha, "url": url}})
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(content)
+        mock_session_cls.return_value = mock_session
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path)])
+        assert result.exit_code == 0
+
+        # File should exist on disk with correct content
+        dest = tmp_path / _FILE_A
+        assert dest.exists()
+        assert dest.read_bytes() == content
+
+        # Session.get was called with the right URL
+        mock_session.get.assert_called_once_with(url, stream=True)
+
+
+class TestCachePullMatchingSkipped:
+    """MATCHING entries are not downloaded."""
+
+    @patch("iqb.cli.cache_pull.requests.Session")
+    def test_skips_matching(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content = b"same content"
+        sha = _sha256(content)
+        _write_manifest(tmp_path, {_FILE_A: {"sha256": sha, "url": "https://example.com/a"}})
+        _make_cache_file(tmp_path, _FILE_A, content)
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "Nothing to download" in result.output
+        mock_session.get.assert_not_called()
+
+
+class TestCachePullMismatchSkippedByDefault:
+    """SHA256_MISMATCH entries are skipped without --force."""
+
+    @patch("iqb.cli.cache_pull.requests.Session")
+    def test_skips_mismatch(self, mock_session_cls: MagicMock, tmp_path: Path):
+        remote_content = b"remote version"
+        local_content = b"local version"
+        _write_manifest(
+            tmp_path,
+            {_FILE_A: {"sha256": _sha256(remote_content), "url": "https://example.com/a"}},
+        )
+        _make_cache_file(tmp_path, _FILE_A, local_content)
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "Nothing to download" in result.output
+        mock_session.get.assert_not_called()
+
+        # Local file should be unchanged
+        assert (tmp_path / _FILE_A).read_bytes() == local_content
+
+
+class TestCachePullMismatchWithForce:
+    """SHA256_MISMATCH entries are downloaded with --force."""
+
+    @patch("iqb.cli.cache_pull.requests.Session")
+    def test_downloads_with_force(self, mock_session_cls: MagicMock, tmp_path: Path):
+        remote_content = b"remote version"
+        local_content = b"local version"
+        _write_manifest(
+            tmp_path,
+            {_FILE_A: {"sha256": _sha256(remote_content), "url": "https://example.com/a"}},
+        )
+        _make_cache_file(tmp_path, _FILE_A, local_content)
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(remote_content)
+        mock_session_cls.return_value = mock_session
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path), "--force"])
+        assert result.exit_code == 0
+
+        # File should be replaced with remote content
+        assert (tmp_path / _FILE_A).read_bytes() == remote_content
+
+
+class TestCachePullSha256Failure:
+    """SHA256 verification failure results in exit code 1."""
+
+    @patch("iqb.cli.cache_pull.requests.Session")
+    def test_sha256_failure(self, mock_session_cls: MagicMock, tmp_path: Path):
+        expected_content = b"expected content"
+        actual_content = b"corrupted content"
+        _write_manifest(
+            tmp_path,
+            {_FILE_A: {"sha256": _sha256(expected_content), "url": "https://example.com/a"}},
+        )
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(actual_content)
+        mock_session_cls.return_value = mock_session
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "download(s) failed" in result.output
+
+        # File should NOT exist on disk (atomic write prevented partial file)
+        assert not (tmp_path / _FILE_A).exists()
+
+
+class TestCachePullMultipleFiles:
+    """Multiple ONLY_REMOTE entries are all downloaded."""
+
+    @patch("iqb.cli.cache_pull.requests.Session")
+    def test_downloads_multiple(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content_a = b"content a"
+        content_b = b"content b"
+        _write_manifest(
+            tmp_path,
+            {
+                _FILE_A: {"sha256": _sha256(content_a), "url": "https://example.com/a"},
+                _FILE_B: {"sha256": _sha256(content_b), "url": "https://example.com/b"},
+            },
+        )
+
+        mock_session = MagicMock()
+
+        def side_effect(url: str, **kwargs):
+            if url == "https://example.com/a":
+                return _fake_response(content_a)
+            return _fake_response(content_b)
+
+        mock_session.get.side_effect = side_effect
+        mock_session_cls.return_value = mock_session
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path)])
+        assert result.exit_code == 0
+        assert (tmp_path / _FILE_A).read_bytes() == content_a
+        assert (tmp_path / _FILE_B).read_bytes() == content_b
+
+
+class TestCachePullJobsFlag:
+    """-j flag is accepted."""
+
+    def test_jobs_flag_accepted(self, tmp_path: Path):
+        _write_manifest(tmp_path, {})
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path), "-j", "4"])
+        assert result.exit_code == 0
+        assert "Nothing to download" in result.output
+
+
+class TestCachePullAtomicWrite:
+    """If download fails, no partial file is left on disk."""
+
+    @patch("iqb.cli.cache_pull.requests.Session")
+    def test_no_partial_file_on_failure(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content = b"some content"
+        _write_manifest(
+            tmp_path,
+            {_FILE_A: {"sha256": _sha256(content), "url": "https://example.com/a"}},
+        )
+
+        mock_session = MagicMock()
+        mock_session.get.side_effect = ConnectionError("connection refused")
+        mock_session_cls.return_value = mock_session
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path)])
+        assert result.exit_code == 1
+
+        # No partial file should exist
+        assert not (tmp_path / _FILE_A).exists()

--- a/uv.lock
+++ b/uv.lock
@@ -1552,6 +1552,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "python-dateutil" },
+    { name = "requests" },
     { name = "rich" },
 ]
 
@@ -1573,6 +1574,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
+    { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=14.2.0" },
 ]
 


### PR DESCRIPTION
The pull command pulls from the remote cache. By default we only pull missing files. One needs to use `-f` to also pull files modified locally. That is, files with hash mismatches, which could mean either results of new queries or to be updated since the manifest changed. The user knows better than us in this case. We don't want to write them since they may be the results of new queries and the user in such a case would be rightfully very pissed off at us.

This code downloads using multiple threads. We did not unify this code and the single-threaded downloader used by the normal remote cache sync that is already implemented. The reason is that this would be a bigger refactoring and, for now, we want to add this new code and play around with it, before knowing _how_ to refactor. Using multiple threads makes fetching faster. To further improve the performance story, we also reuse existing connections.