### PR TITLE
Add GitHub issue templates (Bug Report, Feature Request, Description)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: "🐛 Bug Report"
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below to help us understand and reproduce the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this behavior?
+      placeholder: |
+        1. Run `uv run ...`
+        2. Navigate to ...
+        3. Click on ...
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include any error messages or logs.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project is affected?
+      options:
+        - Library (`library/`)
+        - Prototype / Streamlit app (`prototype/`)
+        - Data pipeline (`data/`)
+        - Analysis / Notebooks (`analysis/`)
+        - Documentation (`docs/`)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please provide details about your environment.
+      placeholder: |
+        - OS: Windows 11 / macOS 15 / Ubuntu 24.04
+        - Python version: 3.13.x
+        - uv version: 0.x.x
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or logs about the problem.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/description.yml
+++ b/.github/ISSUE_TEMPLATE/description.yml
@@ -1,0 +1,48 @@
+name: "📝 Description"
+description: General issue, question, or discussion topic
+title: "[Description]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for general issues, questions, or topics that don't fit into bug reports or feature requests.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Provide a clear and concise summary of the issue or topic.
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Elaborate on the issue with as much detail as needed.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Related Component
+      description: Which part of the project does this relate to (if any)?
+      options:
+        - Library (`library/`)
+        - Prototype / Streamlit app (`prototype/`)
+        - Data pipeline (`data/`)
+        - Analysis / Notebooks (`analysis/`)
+        - Documentation (`docs/`)
+        - General / Not specific
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any additional context, links, or references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: "✨ Feature Request"
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to improve the project? We'd love to hear it! Please describe your feature request below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is this feature request related to a problem? Describe it.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project would this affect?
+      options:
+        - Library (`library/`)
+        - Prototype / Streamlit app (`prototype/`)
+        - Data pipeline (`data/`)
+        - Analysis / Notebooks (`analysis/`)
+        - Documentation (`docs/`)
+        - Multiple components
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or references about the feature request.
+    validations:
+      required: false


### PR DESCRIPTION
## What

Adds structured GitHub issue templates using YAML issue forms, so the **"New Issue"** page presents contributors with 3 clear options instead of a blank editor.

## Why

The repository currently has no issue templates, which leads to:
- Inconsistent issue formatting
- Missing context (no reproduction steps, no environment info, etc.)
- Extra back-and-forth between maintainers and reporters

## Changes

### Templates added

| Template | File | Auto-label | Key Fields |
|----------|------|------------|------------|
|  Bug Report | [bug_report.yml](cci:7://file:///c:/Users/BIT/desktop/iqb/.github/ISSUE_TEMPLATE/bug_report.yml:0:0-0:0) | `bug` | Description, repro steps, expected/actual behavior, component, environment |
|  Feature Request | [feature_request.yml](cci:7://file:///c:/Users/BIT/desktop/iqb/.github/ISSUE_TEMPLATE/feature_request.yml:0:0-0:0) | `enhancement` | Problem statement, proposed solution, alternatives, component |
|  Description | [description.yml](cci:7://file:///c:/Users/BIT/desktop/iqb/.github/ISSUE_TEMPLATE/description.yml:0:0-0:0) | `question` | Summary, details, related component |

### Configuration

- [config.yml](cci:7://file:///c:/Users/BIT/desktop/iqb/.github/ISSUE_TEMPLATE/config.yml:0:0-0:0) — Disables blank issues so all issues follow a template

## Component dropdown options

All templates include a dropdown to identify the affected component:
- Library (`library/`)
- Prototype / Streamlit app (`prototype/`)
- Data pipeline (`data/`)
- Analysis / Notebooks (`analysis/`)
- Documentation (`docs/`)

## How to test

1. Merge this PR into `main`
2. Go to **Issues → New Issue**
3. Verify the 3 template options appear as a chooser