### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## Description
+
+<!-- Provide a concise summary of your changes and the motivation behind them. -->
+
+## Related Issue
+
+<!-- Link the issue this PR addresses. Use "Closes #<number>" to auto-close it on merge. -->
+
+Closes #
+
+## Type of Change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring / code cleanup (no functional changes)
+- [ ] Test update (adding or modifying tests only)
+
+## Component(s) Affected
+
+<!-- Check all that apply. -->
+
+- [ ] Library (`library/`)
+- [ ] Prototype / Streamlit app (`prototype/`)
+- [ ] Data pipeline (`data/`)
+- [ ] Analysis / Notebooks (`analysis/`)
+- [ ] Documentation (`docs/`)
+- [ ] CI / GitHub Actions (`.github/`)
+- [ ] Other (please specify):
+
+## How Has This Been Tested?
+
+<!-- Describe how you tested your changes (e.g., `uv run pytest`, manual testing). -->
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
+- [ ] My changes follow the existing code style (checked with `uv run ruff check`).
+- [ ] I have added or updated tests as appropriate.
+- [ ] All tests pass locally (`uv run pytest`).
+- [ ] I have updated documentation if needed.


### PR DESCRIPTION
## Description

Add [.github/pull_request_template.md](cci:7://file:///c:/Users/BIT/desktop/iqb/.github/pull_request_template.md:0:0-0:0) to provide a consistent structure for all pull requests. The template includes sections for description, related issue linking, type of change, affected components, testing details, and a pre-merge checklist.

This aligns with the existing issue templates (bug report, feature request, description) and references the project's tooling (`uv`, `ruff`, `pytest`) and [CONTRIBUTING.md](cci:7://file:///c:/Users/BIT/desktop/iqb/CONTRIBUTING.md:0:0-0:0) guide.

## Related Issue

Closes #148 

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

- [x] CI / GitHub Actions (`.github/`)

## How Has This Been Tested?

Verified that the template renders correctly on GitHub by previewing the markdown. No code logic changes — this is a documentation/workflow addition only.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide.
- [x] My changes follow the existing code style.
- [x] I have updated documentation if needed.