### PR TITLE
Apply custom thresholds and weights to Streamlit IQB score computation

### DIFF
--- a/library/src/iqb/calculator.py
+++ b/library/src/iqb/calculator.py
@@ -1,5 +1,6 @@
 """Module that implements calculating IQB scores."""
 
+import copy
 from pprint import pprint
 
 from .config import IQB_CONFIG
@@ -13,20 +14,29 @@ class IQBCalculator:
         Initialize a new instance of IQBCalculator.
 
         Parameters:
-            config (str): The file with the configuration of the IQB formula parameters. If "None" (default), it gets the parameters from the IQB_CONFIG dict.
+            config (dict | str): If "None" (default), use IQB_CONFIG. A dict is used
+                as in-memory configuration. A string is currently treated as a
+                configuration file path and is not implemented.
             name (str): [Optional] name for the IQBCalculator instance.
         """
         self.set_config(config)
         self.name = name
 
     def set_config(self, config):
-        """Sets up configuration parameters. If "None" (default), it gets the parameters from the IQB_CONFIG dict."""
+        """Set up configuration parameters."""
         if config is None:
             self.config = IQB_CONFIG
-        else:
+        elif isinstance(config, dict):
+            # Keep calculator behavior isolated from external mutations.
+            self.config = copy.deepcopy(config)
+        elif isinstance(config, str):
             # TODO: load config data from file (json, yaml, or other format) as a dict
             raise NotImplementedError(
                 "method for reading from configuration file other than the default not implemented"
+            )
+        else:
+            raise TypeError(
+                f"config must be None, dict, or str, got: {type(config).__name__}"
             )
 
     def print_config(self):
@@ -36,27 +46,27 @@ class IQBCalculator:
         """
         # TODO: to be updated
         print("### IQB formula weights and thresholds")
-        pprint(IQB_CONFIG)
+        pprint(self.config)
         print()
 
         print("### Use cases")
-        for uc in IQB_CONFIG["use cases"]:
+        for uc in self.config["use cases"]:
             print(f"\t{uc}")
         print()
 
         print("### Network requirements")
-        for uc in IQB_CONFIG["use cases"]:
-            for nr in IQB_CONFIG["use cases"][uc]["network requirements"]:
+        for uc in self.config["use cases"]:
+            for nr in self.config["use cases"][uc]["network requirements"]:
                 print(f"\t{nr}")
             break
         print()
 
         print("### Weights & Thresholds")
         print("\tUse case\t \tNetwork requirement \tWeight \tThreshold min")
-        for uc in IQB_CONFIG["use cases"]:
-            for nr in IQB_CONFIG["use cases"][uc]["network requirements"]:
-                nr_w = IQB_CONFIG["use cases"][uc]["network requirements"][nr]["w"]
-                nr_th = IQB_CONFIG["use cases"][uc]["network requirements"][nr]["threshold min"]
+        for uc in self.config["use cases"]:
+            for nr in self.config["use cases"][uc]["network requirements"]:
+                nr_w = self.config["use cases"][uc]["network requirements"][nr]["w"]
+                nr_th = self.config["use cases"][uc]["network requirements"][nr]["threshold min"]
                 print(f"\t{uc:20} \t{nr:20} \t{nr_w} \t{nr_th}")
         print()
 

--- a/prototype/Home.py
+++ b/prototype/Home.py
@@ -2,7 +2,10 @@
 
 import streamlit as st
 from session_state import initialize_app_state
-from utils.calculation_utils import build_data_for_calculate
+from utils.calculation_utils import (
+    build_data_for_calculate,
+    calculate_iqb_score_with_custom_settings,
+)
 from visualizations.sunburst_data import (
     prepare_complete_hierarchy_sunburst_data,
     prepare_requirements_sunburst_data,
@@ -69,8 +72,8 @@ def main():
     with right_col:
         try:
             data_for_calculation = build_data_for_calculate(state)
-            iqb_score = state.iqb.calculate_iqb_score(
-                data=data_for_calculation, print_details=False
+            iqb_score = calculate_iqb_score_with_custom_settings(
+                state, data=data_for_calculation, print_details=False
             )
 
             tab1, tab2, tab3 = st.tabs(["Requirements", "Use Cases", "Full Hierarchy"])

--- a/prototype/tests/calculation_utils_test.py
+++ b/prototype/tests/calculation_utils_test.py
@@ -1,0 +1,48 @@
+"""Tests for prototype calculation utilities."""
+
+from session_state import initialize_app_state
+from utils.calculation_utils import (
+    build_data_for_calculate,
+    calculate_iqb_score_with_custom_settings,
+    get_config_with_custom_settings,
+)
+
+
+def test_get_config_with_custom_settings_applies_state_values():
+    """Config builder should apply threshold and weight overrides from state."""
+    state = initialize_app_state()
+
+    state.thresholds["web browsing"]["download_throughput_mbps"] = 500
+    state.requirement_weights["web browsing"]["latency_ms"] = 1
+    state.use_case_weights["gaming"] = 2
+
+    config = get_config_with_custom_settings(state)
+
+    assert (
+        config["use cases"]["web browsing"]["network requirements"][
+            "download_throughput_mbps"
+        ]["threshold min"]
+        == 500
+    )
+    assert (
+        config["use cases"]["web browsing"]["network requirements"]["latency_ms"]["w"] == 1
+    )
+    assert config["use cases"]["gaming"]["w"] == 2
+
+
+def test_calculate_iqb_score_with_custom_settings_changes_result():
+    """Applying strict thresholds in state should lower score for same input data."""
+    state = initialize_app_state()
+    data = build_data_for_calculate(state)
+
+    baseline_score = calculate_iqb_score_with_custom_settings(state, data)
+
+    for use_case in state.thresholds.values():
+        use_case["download_throughput_mbps"] = 500
+        use_case["upload_throughput_mbps"] = 500
+        use_case["latency_ms"] = 5
+        use_case["packet_loss"] = 0.001
+
+    strict_score = calculate_iqb_score_with_custom_settings(state, data)
+
+    assert strict_score < baseline_score

--- a/prototype/utils/calculation_utils.py
+++ b/prototype/utils/calculation_utils.py
@@ -4,7 +4,7 @@ import copy
 from typing import Dict, Tuple
 
 from app_state import IQBAppState
-from iqb import IQB_CONFIG
+from iqb import IQB, IQB_CONFIG
 from utils.data_utils import get_available_datasets, get_available_requirements
 
 
@@ -66,6 +66,15 @@ def get_config_with_custom_settings(state: IQBAppState) -> Dict:
             ]
 
     return modified_config
+
+
+def calculate_iqb_score_with_custom_settings(
+    state: IQBAppState, data: Dict[str, Dict[str, float]], print_details: bool = False
+) -> float:
+    """Calculate IQB score using current UI-customized thresholds and weights."""
+    custom_config = get_config_with_custom_settings(state)
+    calculator = IQB(config=custom_config)
+    return calculator.calculate_iqb_score(data=data, print_details=print_details)
 
 
 def calculate_component_importance() -> Dict[str, float]:


### PR DESCRIPTION
## Summary
This PR fixes a correctness bug in the Streamlit prototype where edited thresholds/weights in the configuration editor were not applied to IQB score computation.

## Why this was happening
The editor updated thresholds/weights in Streamlit session state, but score calculation paths still used the default calculator instance (`state.iqb`) initialized with default config.  
So UI changes were visible, but the score logic ignored them.

## Root cause
- Prototype score paths called `state.iqb.calculate_iqb_score(...)` directly.
- `state.iqb` used default config only.
- `IQBCalculator.set_config` did not support in-memory dict config.
- Custom-config builder existed but was not connected to score computation paths.

## What changed
- Added dict-config support in calculator: `library/src/iqb/calculator.py`
- Added custom-settings score helper: `prototype/utils/calculation_utils.py`
- Added `calculate_iqb_score_with_custom_settings(...)` helper usage in scoring paths.
- Rewired score paths in `prototype/Home.py` and `prototype/pages/IQB_Map.py`.
- Added regression tests in `library/tests/iqb/calculator_test.py`.
- Added regression tests in `prototype/tests/calculation_utils_test.py`.

## Validation

### Automated tests
Ran:
`uv run pytest library/tests/iqb/calculator_test.py prototype/tests/calculation_utils_test.py`

Result:
- `30 passed in 4.02s`

Key tests:
- `calculator_test.py::TestIQBCalculatorScoreCalculation::test_calculate_iqb_score_changes_with_custom_thresholds`
- `calculation_utils_test.py::test_calculate_iqb_score_with_custom_settings_changes_result`

### Behavior proof (script)
With fixed baseline inputs and strict thresholds:
- `baseline=0.571429`
- `strict=0.000000`
- `decreased=True`

### Manual proof of concept
Fixed inputs:
- Download: `15.00`
- Upload: `20.00`
- Latency: `75.00`
- Packet Loss: `0.700`

Strict thresholds (all use-case tabs):
- Download: `500`
- Upload: `500`
- Latency: `5`
- Packet Loss: `0.100`

Observed:
- IQB score decreases after edits (no longer stays unchanged).

## Screenshots
Before score (`proof_before_score.png`):
<img width="1420" height="847" alt="before_after_correct" src="https://github.com/user-attachments/assets/354bdcf8-d648-4a75-a904-21c328be937a" />

Config changed (`proof_config_changed.png`):
<img width="1437" height="817" alt="check_after_corect" src="https://github.com/user-attachments/assets/2b4022e8-767b-4e90-8040-ad20777675fa" />

After score (`proof_after_score.png`):
<img width="1427" height="868" alt="after_after_corect" src="https://github.com/user-attachments/assets/04065384-d43b-4fbc-9e6b-1403532b31a9" />

## Impact
- Fixes user-visible scoring correctness in prototype.
- Makes “what-if” config editing reliable.
- Keeps displayed scores aligned with edited thresholds/weights.

## Issue
Closes  #158 


