### PR TITLE
doc(queries): name the better tables to switch to

### DIFF
--- a/library/src/iqb/queries/downloads_by_country.sql
+++ b/library/src/iqb/queries/downloads_by_country.sql
@@ -65,7 +65,7 @@ SELECT
     APPROX_QUANTILES(a.LossRate, 100)[OFFSET(1)] as loss_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country.sql
+++ b/library/src/iqb/queries/downloads_by_country.sql
@@ -66,6 +66,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_asn.sql
+++ b/library/src/iqb/queries/downloads_by_country_asn.sql
@@ -67,7 +67,7 @@ SELECT
     APPROX_QUANTILES(a.LossRate, 100)[OFFSET(1)] as loss_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_asn.sql
+++ b/library/src/iqb/queries/downloads_by_country_asn.sql
@@ -68,6 +68,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_city.sql
+++ b/library/src/iqb/queries/downloads_by_country_city.sql
@@ -69,6 +69,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_city.sql
+++ b/library/src/iqb/queries/downloads_by_country_city.sql
@@ -68,7 +68,7 @@ SELECT
     APPROX_QUANTILES(a.LossRate, 100)[OFFSET(1)] as loss_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_city_asn.sql
+++ b/library/src/iqb/queries/downloads_by_country_city_asn.sql
@@ -71,6 +71,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_city_asn.sql
+++ b/library/src/iqb/queries/downloads_by_country_city_asn.sql
@@ -70,7 +70,7 @@ SELECT
     APPROX_QUANTILES(a.LossRate, 100)[OFFSET(1)] as loss_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_subdivision1.sql
+++ b/library/src/iqb/queries/downloads_by_country_subdivision1.sql
@@ -67,7 +67,7 @@ SELECT
     APPROX_QUANTILES(a.LossRate, 100)[OFFSET(1)] as loss_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_subdivision1.sql
+++ b/library/src/iqb/queries/downloads_by_country_subdivision1.sql
@@ -68,6 +68,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_subdivision1_asn.sql
+++ b/library/src/iqb/queries/downloads_by_country_subdivision1_asn.sql
@@ -70,6 +70,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/downloads_by_country_subdivision1_asn.sql
+++ b/library/src/iqb/queries/downloads_by_country_subdivision1_asn.sql
@@ -69,7 +69,7 @@ SELECT
     APPROX_QUANTILES(a.LossRate, 100)[OFFSET(1)] as loss_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_downloads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country.sql
+++ b/library/src/iqb/queries/uploads_by_country.sql
@@ -26,6 +26,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country.sql
+++ b/library/src/iqb/queries/uploads_by_country.sql
@@ -25,7 +25,7 @@ SELECT
     APPROX_QUANTILES(a.MeanThroughputMbps, 100)[OFFSET(99)] as upload_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_asn.sql
+++ b/library/src/iqb/queries/uploads_by_country_asn.sql
@@ -28,6 +28,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_asn.sql
+++ b/library/src/iqb/queries/uploads_by_country_asn.sql
@@ -27,7 +27,7 @@ SELECT
     APPROX_QUANTILES(a.MeanThroughputMbps, 100)[OFFSET(99)] as upload_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_city.sql
+++ b/library/src/iqb/queries/uploads_by_country_city.sql
@@ -29,6 +29,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_city.sql
+++ b/library/src/iqb/queries/uploads_by_country_city.sql
@@ -28,7 +28,7 @@ SELECT
     APPROX_QUANTILES(a.MeanThroughputMbps, 100)[OFFSET(99)] as upload_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_city_asn.sql
+++ b/library/src/iqb/queries/uploads_by_country_city_asn.sql
@@ -31,6 +31,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_city_asn.sql
+++ b/library/src/iqb/queries/uploads_by_country_city_asn.sql
@@ -30,7 +30,7 @@ SELECT
     APPROX_QUANTILES(a.MeanThroughputMbps, 100)[OFFSET(99)] as upload_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_subdivision1.sql
+++ b/library/src/iqb/queries/uploads_by_country_subdivision1.sql
@@ -28,6 +28,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_subdivision1.sql
+++ b/library/src/iqb/queries/uploads_by_country_subdivision1.sql
@@ -27,7 +27,7 @@ SELECT
     APPROX_QUANTILES(a.MeanThroughputMbps, 100)[OFFSET(99)] as upload_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_subdivision1_asn.sql
+++ b/library/src/iqb/queries/uploads_by_country_subdivision1_asn.sql
@@ -29,7 +29,7 @@ SELECT
     APPROX_QUANTILES(a.MeanThroughputMbps, 100)[OFFSET(99)] as upload_p99
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
-    -- support. We'll eventually need to switch to better tables.
+    -- support. We'll eventually need to switch to ndt7_union.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"

--- a/library/src/iqb/queries/uploads_by_country_subdivision1_asn.sql
+++ b/library/src/iqb/queries/uploads_by_country_subdivision1_asn.sql
@@ -30,6 +30,7 @@ SELECT
 FROM
     -- TODO(bassosimone): current unified_downloads/unified_uploads tables lack BYOS
     -- support. We'll eventually need to switch to ndt7_union.
+    -- See https://github.com/m-lab/iqb/pull/189 for additional context.
     `measurement-lab.ndt.unified_uploads`
 WHERE
     date >= "{START_DATE}" AND date < "{END_DATE}"


### PR DESCRIPTION
The comment was vague and did not specify which are the better tables
and why to switch to them. Now, instead, we are specific and correctly
name the `ndt7_union` table.

As the comment already specified, `ndt7_union` is a "better" table than
what we're currently using because it also includes BYOS data, while
current tables do not.

In the diff, we also explain why switching to `ndt7_union` is "better"
by back-referencing this PR. The specific blocker, documented
in our internal ClickUp, is basically that `ndt7_union` does not include
data quality filters that the current tables apply (e.g., excluding very
short tests). We will either need to reimplement these data quality checks
in the IQB queries or in the code that produces `ndt7_union`.
