### PR TITLE
fix(library): support python3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,28 @@ jobs:
         working-directory: library
         run: uv run pytest --tb=short -q
 
+  test-library-py312:
+    name: Test Library on Python 3.12 (standalone install)
+    # Colab runs Python 3.12, so the published library must work there. This
+    # job installs the library outside the workspace context (--no-project)
+    # against a fresh 3.12 interpreter, which doubles as a smoke test that
+    # all runtime dependencies are properly declared in library/pyproject.toml.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Run library tests against standalone Python 3.12 install
+        working-directory: library
+        run: uv run --no-project --with . --with pytest --python 3.12 pytest --tb=short -q
+
   test-prototype-integration:
     name: Test Streamlit Prototype Integration
     runs-on: ubuntu-latest

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mlab-iqb"
 description = "Internet Quality Barometer (IQB) library for calculating composite quality scores"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "Measurement Lab", email = "support@measurementlab.net"}
@@ -23,6 +23,8 @@ dependencies = [
     "click>=8.1.0",
     "requests>=2.28.0",
     "google-cloud-storage>=2.0.0",
+    "typing-extensions>=4.5.0",
+    "pyyaml>=6.0",
 ]
 
 [project.urls]
@@ -72,7 +74,7 @@ addopts = [
 
 [tool.ruff]
 line-length = 100
-target-version = "py313"
+target-version = "py312"
 
 [tool.ruff.format]
 indent-style = "space"
@@ -105,6 +107,6 @@ known-first-party = ["iqb"]
 [tool.pyright]
 include = ["src", "tests"]
 exclude = ["**/__pycache__", ".venv"]
-pythonVersion = "3.13"
+pythonVersion = "3.12"
 typeCheckingMode = "basic"
 reportMissingTypeStubs = false

--- a/library/src/iqb/cache/cache.py
+++ b/library/src/iqb/cache/cache.py
@@ -1,11 +1,11 @@
 """Module implementing IQBCache."""
 
-import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
 from dateutil.relativedelta import relativedelta
+from typing_extensions import deprecated
 
 from ..pipeline.dataset import IQBDatasetGranularity
 from ..pipeline.pipeline import PipelineCacheManager, PipelineRemoteCache
@@ -162,7 +162,7 @@ class IQBCache:
         # 4. Fill the result
         return IQBData(mlab=mlab_data)
 
-    @warnings.deprecated("use get_iqb_data instead")
+    @deprecated("use get_iqb_data instead")
     def get_data(
         self,
         country: str,

--- a/uv.lock
+++ b/uv.lock
@@ -1674,8 +1674,10 @@ dependencies = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "python-dateutil" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -1697,8 +1699,10 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "rich", specifier = ">=14.2.0" },
+    { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
As reported by @zarsl, colab uses python3.12 and the library was written with python3.13 in mind. Fix this by:

1. pinning the library to `python>=3.12`

2. updating `ruff` and `pyright` config to use 3.12

3. use `typing_extensions` to get `warnings.deprecated` equivalent functionality when it is not available

4. adding a CI check ensuring that a fresh install of the library on python3.12 passes all tests

While there, notice that `pyyaml` was not declared as an explicit library dependency and fix that as well. Ahead of this fix, `pyyaml` was used by `iqb.cli.pipeline_run` and everything was WAI because it was a transitive dependency of another dependency. So, the code wasn't broken but it was possibly poised to break in the future.