### PR TITLE
fix(l/pyproject.toml): drop force-includes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,25 @@ jobs:
         working-directory: library
         run: uv run --no-project --with . --with pytest --python 3.12 pytest --tb=short -q
 
+  test-library-wheel:
+    name: Test Library Wheel Packaging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Build wheel and verify SQL queries are packaged
+        run: ./scripts/test-wheel.sh
+
   test-prototype-integration:
     name: Test Streamlit Prototype Integration
     runs-on: ubuntu-latest

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -42,9 +42,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/iqb"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/iqb/queries" = "iqb/queries"
-
 [tool.hatch.version]
 source = "vcs"
 fallback-version = "0.0.0"

--- a/scripts/test-wheel.sh
+++ b/scripts/test-wheel.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# This script ensures that we can always build a wheel and that
+# the wheel includes the SQL queries.
+#
+# See https://github.com/m-lab/iqb/issues/199.
+
+set -eu
+
+OUTDIR=$(mktemp -d)
+trap 'rm -rf "$OUTDIR"' EXIT
+
+# Emit the wheel into an output directory
+uv build library/ --out-dir "$OUTDIR"
+
+# Make sure the wheel can be imported and contains SQL files
+uv run --no-project --with "$OUTDIR"/*.whl --python 3.13 python3 -c "
+from importlib.resources import files
+import iqb.queries
+sql = [f.name for f in files(iqb.queries).iterdir() if f.name.endswith('.sql')]
+assert len(sql) > 0, 'No .sql files found in installed wheel'
+for name in sql:
+    text = files(iqb.queries).joinpath(name).read_text(encoding='utf-8')
+    assert len(text) > 0, f'{name} is empty'
+print(f'OK: {len(sql)} SQL query files verified in wheel')
+"


### PR DESCRIPTION
I added `force-includes` as a belt-and-suspenders to ensure we did bundle SQL queries. However, it turns out that it prevented usage (see https://github.com/m-lab/iqb/issues/199).

I tested what happens when dropping it, and we're still bundling queries when installing, so `force-includes` can be culled without additional side effects. Good to know.

This commit also includes a testing script making sure that my claim above ("wheel working as intended") is valid now per the CI and will continue to be valid as we evolve the library.

Closes https://github.com/m-lab/iqb/issues/199.