### PR TITLE
refactor(ghremote): parse (not validate) manifest keys

### DIFF
--- a/library/src/iqb/cli/cache_pull.py
+++ b/library/src/iqb/cli/cache_pull.py
@@ -25,6 +25,7 @@ from rich.progress import (
 
 from ..ghremote import DiffState, diff, load_manifest, manifest_path_for_data_dir
 from ..ghremote.diff import DiffEntry
+from ..ghremote.entrypath import ManifestEntryPath
 from ..pipeline.cache import data_dir_or_default
 from .cache import cache
 
@@ -38,10 +39,9 @@ def _get_session() -> requests.Session:
     return _thread_local.session
 
 
-def _short_name(file: str) -> str:
-    """Extract a short display name from a cache path."""
-    parts = file.split("/")
-    return "/".join(parts[-2:]) if len(parts) >= 2 else file
+def _short_name(path: ManifestEntryPath) -> str:
+    """Extract a short display name from a manifest entry path."""
+    return f"{path.dataset}/{path.filename}"
 
 
 def _now() -> str:
@@ -63,7 +63,7 @@ def _download_one(
     error: str | None = None
     assert entry.url is not None
     assert entry.remote_sha256 is not None
-    dest = data_dir / entry.file
+    dest = data_dir / Path(str(entry.file))
     dest.parent.mkdir(parents=True, exist_ok=True)
     task_id = progress.add_task(_short_name(entry.file), total=None)
     try:
@@ -86,7 +86,7 @@ def _download_one(
             got = sha256.hexdigest()
             if got != entry.remote_sha256:
                 raise ValueError(
-                    f"SHA256 mismatch for {entry.file}: expected {entry.remote_sha256}, got {got}"
+                    f"SHA256 mismatch for {str(entry.file)}: expected {entry.remote_sha256}, got {got}"
                 )
             os.replace(tmp_file, dest)
     except Exception as exc:
@@ -98,7 +98,7 @@ def _download_one(
         "t0": t0,
         "t": _now(),
         "worker_id": worker_id,
-        "file": entry.file,
+        "file": str(entry.file),
         "url": entry.url,
         "content_length": content_length,
         "bytes": total_bytes,
@@ -153,7 +153,7 @@ def pull(data_dir: str | None, force: bool, jobs: int) -> None:
                     failed.append((str(span["file"]), str(span["error"] or "unknown")))
             except Exception as exc:
                 # Defensive: bug in _download_one itself
-                failed.append((entry.file, str(exc)))
+                failed.append((str(entry.file), str(exc)))
     elapsed = time.monotonic() - t0
 
     # Write metrics

--- a/library/src/iqb/cli/cache_push.py
+++ b/library/src/iqb/cli/cache_push.py
@@ -22,6 +22,7 @@ from ..ghremote import (
     save_manifest,
 )
 from ..ghremote.diff import DiffEntry
+from ..ghremote.entrypath import ManifestEntryPath
 from ..pipeline.cache import data_dir_or_default
 from ..scripting import iqb_logging
 from .cache import cache
@@ -30,10 +31,9 @@ _DEFAULT_BUCKET = "mlab-sandbox-iqb-us-central1"
 _GCS_BASE_URL = "https://storage.googleapis.com"
 
 
-def _short_name(file: str) -> str:
-    """Extract a short display name from a cache path."""
-    parts = file.split("/")
-    return "/".join(parts[-2:]) if len(parts) >= 2 else file
+def _short_name(path: ManifestEntryPath) -> str:
+    """Extract a short display name from a manifest entry path."""
+    return f"{path.dataset}/{path.filename}"
 
 
 class _ProgressReader:
@@ -66,17 +66,17 @@ def _upload_one(
 ) -> str:
     """Upload a single file to GCS with progress tracking. Returns the file path."""
     assert entry.local_sha256 is not None
-    source = data_dir / entry.file
+    source = data_dir / Path(str(entry.file))
     file_size = source.stat().st_size
     task_id = progress.add_task(_short_name(entry.file), total=file_size)
     try:
-        blob = bucket.blob(entry.file)
+        blob = bucket.blob(str(entry.file))
         with open(source, "rb") as fp:
             reader = _ProgressReader(fp, progress, task_id)
             blob.upload_from_file(reader, size=file_size)
     finally:
         progress.remove_task(task_id)
-    return entry.file
+    return str(entry.file)
 
 
 @cache.command()
@@ -117,11 +117,11 @@ def push(data_dir: str | None, bucket: str, force: bool) -> None:
             try:
                 _upload_one(entry, resolved, gcs_bucket, progress)
             except Exception as exc:
-                failed.append((entry.file, str(exc)))
+                failed.append((str(entry.file), str(exc)))
                 continue
             # Update manifest after each successful upload (crash-safe)
             assert entry.local_sha256 is not None
-            url = f"{_GCS_BASE_URL}/{bucket}/{entry.file}"
+            url = f"{_GCS_BASE_URL}/{bucket}/{str(entry.file)}"
             manifest.files[entry.file] = FileEntry(sha256=entry.local_sha256, url=url)
             save_manifest(manifest, manifest_path)
     elapsed = time.monotonic() - t0

--- a/library/src/iqb/ghremote/__init__.py
+++ b/library/src/iqb/ghremote/__init__.py
@@ -28,10 +28,12 @@ from .cache import (
     IQBRemoteCache,
     Manifest,
     load_manifest,
+    load_manifest_from_dict,
     manifest_path_for_data_dir,
     save_manifest,
 )
 from .diff import DiffEntry, DiffState, diff
+from .entrypath import ManifestEntryPath, parse_entry_path
 
 # Backward compatibility alias
 IQBGitHubRemoteCache = IQBRemoteCache
@@ -40,11 +42,14 @@ __all__ = [
     "DiffEntry",
     "DiffState",
     "FileEntry",
+    "ManifestEntryPath",
     "IQBGitHubRemoteCache",
     "IQBRemoteCache",
     "Manifest",
     "diff",
     "load_manifest",
+    "load_manifest_from_dict",
     "manifest_path_for_data_dir",
+    "parse_entry_path",
     "save_manifest",
 ]

--- a/library/src/iqb/ghremote/cache.py
+++ b/library/src/iqb/ghremote/cache.py
@@ -24,6 +24,7 @@ from rich.progress import (
 )
 
 from ..pipeline.cache import PipelineCacheEntry, data_dir_or_default
+from .entrypath import ManifestEntryPath, parse_entry_path
 
 log = logging.getLogger("iqb.ghremote.cache")
 
@@ -37,11 +38,19 @@ class FileEntry:
 
 
 @dataclass(kw_only=True)
+class _RawManifest:
+    """JSON-faithful manifest used for (de)serialization only."""
+
+    v: int
+    files: dict[str, FileEntry] = field(default_factory=dict)
+
+
+@dataclass(kw_only=True)
 class Manifest:
     """Manifest for remotely cached files."""
 
     v: int
-    files: dict[str, FileEntry] = field(default_factory=dict)
+    files: dict[ManifestEntryPath, FileEntry] = field(default_factory=dict)
 
     def __post_init__(self):
         if self.v != 0:
@@ -56,11 +65,24 @@ class Manifest:
         """
         # Use .as_posix() to ensure forward slashes for cross-platform compatibility
         # Manifest keys should always use forward slashes regardless of OS
-        key = full_path.relative_to(data_dir).as_posix()
+        key_str = full_path.relative_to(data_dir).as_posix()
+        try:
+            key = parse_entry_path(key_str)
+        except ValueError as exc:
+            raise KeyError(f"no remotely-cached file for {key_str}") from exc
         try:
             return self.files[key]
         except KeyError as exc:
-            raise KeyError(f"no remotely-cached file for {key}") from exc
+            raise KeyError(f"no remotely-cached file for {key_str}") from exc
+
+
+def load_manifest_from_dict(data: dict) -> Manifest:
+    """Parse a manifest from a JSON-decoded dictionary."""
+    raw = from_dict(_RawManifest, data)
+    files: dict[ManifestEntryPath, FileEntry] = {}
+    for raw_key, entry in raw.files.items():
+        files[parse_entry_path(raw_key)] = entry
+    return Manifest(v=raw.v, files=files)
 
 
 def load_manifest(manifest_file: Path) -> Manifest:
@@ -71,7 +93,7 @@ def load_manifest(manifest_file: Path) -> Manifest:
     with open(manifest_file, encoding="utf-8") as filep:
         data = json.load(filep)
 
-    return from_dict(Manifest, data)
+    return load_manifest_from_dict(data)
 
 
 def manifest_path_for_data_dir(data_dir: Path) -> Path:
@@ -81,9 +103,11 @@ def manifest_path_for_data_dir(data_dir: Path) -> Path:
 
 def save_manifest(manifest: Manifest, manifest_file: Path) -> None:
     """Save manifest to the given file path."""
+    raw_files = {str(k): asdict(v) for k, v in manifest.files.items()}
+    raw = {"v": manifest.v, "files": raw_files}
     manifest_file.parent.mkdir(parents=True, exist_ok=True)
     with open(manifest_file, "w", encoding="utf-8") as filep:
-        json.dump(asdict(manifest), filep, indent=2, sort_keys=True)
+        json.dump(raw, filep, indent=2, sort_keys=True)
         filep.write("\n")
 
 

--- a/library/src/iqb/ghremote/diff.py
+++ b/library/src/iqb/ghremote/diff.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
 from .cache import FileEntry, Manifest, compute_sha256
+from .entrypath import ManifestEntryPath, parse_entry_path
 
 log = logging.getLogger("iqb.ghremote.diff")
 
@@ -27,49 +27,16 @@ class DiffState(StrEnum):
 class DiffEntry:
     """Single entry in a manifest-vs-local diff."""
 
-    file: str
+    file: ManifestEntryPath
     url: str | None
     remote_sha256: str | None
     local_sha256: str | None
     state: DiffState
 
 
-def _validate_cache_path(path: str) -> bool:
-    """
-    Validate that a path follows the cache/v1 format.
-
-    Valid format:
-      cache/v1/{rfc3339_timestamp}/{rfc3339_timestamp}/{name}/{file}
-
-    Where:
-      - Component 1: "cache"
-      - Component 2: "v1"
-      - Component 3: RFC3339 timestamp (e.g., 20241001T000000Z)
-      - Component 4: RFC3339 timestamp
-      - Component 5: lowercase letters, numbers, and underscores [a-z0-9_]+
-      - Component 6: "data.parquet" or "stats.json"
-    """
-    parts = path.split("/")
-    if len(parts) != 6:
-        return False
-    if parts[0] != "cache":
-        return False
-    if parts[1] != "v1":
-        return False
-    rfc3339_pattern = re.compile(r"^\d{8}T\d{6}Z$")
-    if not rfc3339_pattern.match(parts[2]):
-        return False
-    if not rfc3339_pattern.match(parts[3]):
-        return False
-    name_pattern = re.compile(r"^[a-z0-9_]+$")
-    if not name_pattern.match(parts[4]):
-        return False
-    return parts[5] in ("data.parquet", "stats.json")
-
-
-def _scan_local_files(data_dir: Path) -> set[str]:
-    """Walk the local cache directory and return validated relative paths."""
-    result: set[str] = set()
+def _scan_local_files(data_dir: Path) -> set[ManifestEntryPath]:
+    """Walk the local cache directory and return parsed entry paths."""
+    result: set[ManifestEntryPath] = set()
     cache_dir = data_dir / "cache" / "v1"
     if not cache_dir.exists():
         return result
@@ -77,8 +44,10 @@ def _scan_local_files(data_dir: Path) -> set[str]:
         if not path.is_file():
             continue
         rel = path.relative_to(data_dir).as_posix()
-        if _validate_cache_path(rel):
-            result.add(rel)
+        try:
+            result.add(parse_entry_path(rel))
+        except ValueError:
+            continue
     return result
 
 
@@ -86,7 +55,7 @@ def diff(
     manifest: Manifest,
     data_dir: Path,
     *,
-    acceptp: Callable[[str], bool] | None = None,
+    acceptp: Callable[[ManifestEntryPath], bool] | None = None,
 ) -> Iterator[DiffEntry]:
     """
     Compare manifest entries against local cache state.
@@ -100,7 +69,7 @@ def diff(
     Args:
         manifest: The loaded manifest to compare against.
         data_dir: Root directory where cache files live on disk.
-        acceptp: Optional predicate applied to relative path strings.
+        acceptp: Optional predicate applied to manifest entry paths.
                  ``None`` means accept everything.
     """
     # Phase 1: scan local files, applying acceptp
@@ -109,16 +78,13 @@ def diff(
         local_files = {f for f in local_files if acceptp(f)}
 
     # Phase 2: iterate accepted manifest keys in sorted order
-    seen: set[str] = set()
-    for key in sorted(manifest.files):
-        if not _validate_cache_path(key):
-            log.warning("skipping invalid manifest key: %s", key)
-            continue
+    seen: set[ManifestEntryPath] = set()
+    for key in sorted(manifest.files, key=str):
         if acceptp is not None and not acceptp(key):
             continue
         seen.add(key)
         entry: FileEntry = manifest.files[key]
-        local_path = data_dir / Path(key)
+        local_path = data_dir / Path(str(key))
         if key not in local_files:
             yield DiffEntry(
                 file=key,
@@ -148,8 +114,8 @@ def diff(
 
     # Phase 3: remaining local files not in manifest
     remaining = local_files - seen
-    for key in sorted(remaining):
-        local_sha256 = compute_sha256(data_dir / Path(key))
+    for key in sorted(remaining, key=str):
+        local_sha256 = compute_sha256(data_dir / Path(str(key)))
         yield DiffEntry(
             file=key,
             url=None,

--- a/library/src/iqb/ghremote/entrypath.py
+++ b/library/src/iqb/ghremote/entrypath.py
@@ -1,0 +1,52 @@
+"""Parsed representation of a manifest entry path."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_RFC3339_RE = re.compile(r"^\d{8}T\d{6}Z$")
+_DATASET_RE = re.compile(r"^[a-z0-9_]+$")
+_VALID_FILENAMES = frozenset(("data.parquet", "stats.json"))
+
+
+@dataclass(frozen=True, kw_only=True)
+class ManifestEntryPath:
+    """Parsed cache path of the form ``cache/v1/{start}/{end}/{dataset}/{filename}``."""
+
+    start: str
+    end: str
+    dataset: str
+    filename: str
+
+    def __str__(self) -> str:
+        return f"cache/v1/{self.start}/{self.end}/{self.dataset}/{self.filename}"
+
+
+def parse_entry_path(raw: str) -> ManifestEntryPath:
+    """Parse a raw cache path string into a :class:`ManifestEntryPath`.
+
+    Raises:
+        ValueError: if the path does not match the expected format.
+    """
+    parts = raw.split("/")
+    if len(parts) != 6:
+        raise ValueError(f"expected 6 path components, got {len(parts)}: {raw!r}")
+    if parts[0] != "cache":
+        raise ValueError(f"first component must be 'cache', got {parts[0]!r}: {raw!r}")
+    if parts[1] != "v1":
+        raise ValueError(f"second component must be 'v1', got {parts[1]!r}: {raw!r}")
+    if not _RFC3339_RE.match(parts[2]):
+        raise ValueError(f"invalid start timestamp {parts[2]!r}: {raw!r}")
+    if not _RFC3339_RE.match(parts[3]):
+        raise ValueError(f"invalid end timestamp {parts[3]!r}: {raw!r}")
+    if not _DATASET_RE.match(parts[4]):
+        raise ValueError(f"invalid dataset {parts[4]!r}: {raw!r}")
+    if parts[5] not in _VALID_FILENAMES:
+        raise ValueError(f"invalid filename {parts[5]!r}: {raw!r}")
+    return ManifestEntryPath(
+        start=parts[2],
+        end=parts[3],
+        dataset=parts[4],
+        filename=parts[5],
+    )

--- a/library/tests/iqb/cli/cache_pull_test.py
+++ b/library/tests/iqb/cli/cache_pull_test.py
@@ -76,10 +76,10 @@ class TestCachePullEmptyManifest:
 
 
 class TestCachePullInvalidManifestKeys:
-    """Invalid manifest keys are ignored for safety."""
+    """Invalid manifest keys are rejected at load time."""
 
     @patch("iqb.cli.cache_pull.requests.Session")
-    def test_traversal_key_is_ignored(self, mock_session_cls: MagicMock, tmp_path: Path):
+    def test_traversal_key_is_rejected(self, mock_session_cls: MagicMock, tmp_path: Path):
         _write_manifest(
             tmp_path,
             {
@@ -93,8 +93,7 @@ class TestCachePullInvalidManifestKeys:
         runner = CliRunner()
         result = runner.invoke(cli, ["cache", "pull", "-d", str(tmp_path)])
 
-        assert result.exit_code == 0
-        assert "Nothing to download" in result.output
+        assert result.exit_code != 0
         mock_session_cls.assert_not_called()
 
 

--- a/library/tests/iqb/ghremote/cache_test.py
+++ b/library/tests/iqb/ghremote/cache_test.py
@@ -17,6 +17,13 @@ from iqb.ghremote.cache import (
     manifest_path_for_data_dir,
     save_manifest,
 )
+from iqb.ghremote.entrypath import parse_entry_path
+
+_TS1 = "20241001T000000Z"
+_TS2 = "20241031T235959Z"
+_DATASET = "test"
+_PARQUET_KEY = f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet"
+_STATS_KEY = f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/stats.json"
 
 
 def _compute_test_sha256(content: bytes) -> str:
@@ -67,7 +74,7 @@ class TestIQBRemoteCacheLoadManifest:
         manifest_data = {
             "v": 0,
             "files": {
-                "cache/v1/2024-01-01/2024-01-31/test/data.parquet": {
+                _PARQUET_KEY: {
                     "sha256": "abc123def456",
                     "url": "https://example.com/file.parquet",
                 }
@@ -79,8 +86,9 @@ class TestIQBRemoteCacheLoadManifest:
 
         assert manifest.v == 0
         assert len(manifest.files) == 1
-        assert "cache/v1/2024-01-01/2024-01-31/test/data.parquet" in manifest.files
-        entry = manifest.files["cache/v1/2024-01-01/2024-01-31/test/data.parquet"]
+        key = parse_entry_path(_PARQUET_KEY)
+        assert key in manifest.files
+        entry = manifest.files[key]
         assert entry.sha256 == "abc123def456"
         assert entry.url == "https://example.com/file.parquet"
 
@@ -102,12 +110,12 @@ class TestManifestGetFileEntry:
         entry = FileEntry(sha256="abc123def456", url="https://example.com/file.parquet")
         manifest = Manifest(
             v=0,
-            files={"cache/v1/2024-01-01/2024-01-31/test/data.parquet": entry},
+            files={parse_entry_path(_PARQUET_KEY): entry},
         )
 
         # Set up paths - using tmp_path to ensure they're realistic
         data_dir = tmp_path / "data"
-        full_path = data_dir / "cache/v1/2024-01-01/2024-01-31/test/data.parquet"
+        full_path = data_dir / _PARQUET_KEY
 
         # Get the entry
         result = manifest.get_file_entry(full_path=full_path, data_dir=data_dir)
@@ -117,6 +125,16 @@ class TestManifestGetFileEntry:
         assert result.sha256 == "abc123def456"
         assert result.url == "https://example.com/file.parquet"
 
+    def test_invalid_path_raises_key_error(self, tmp_path):
+        """Verify that an unparseable relative path raises KeyError."""
+        manifest = Manifest(v=0, files={})
+
+        data_dir = tmp_path / "data"
+        full_path = data_dir / "not" / "a" / "cache" / "path.txt"
+
+        with pytest.raises(KeyError, match="no remotely-cached file for"):
+            manifest.get_file_entry(full_path=full_path, data_dir=data_dir)
+
     def test_failure(self, tmp_path):
         """Verify that we raise KeyError when the entry does not exist."""
         # Create an empty manifest
@@ -124,11 +142,10 @@ class TestManifestGetFileEntry:
 
         # Set up paths
         data_dir = tmp_path / "data"
-        full_path = data_dir / "cache/v1/2024-01-01/2024-01-31/test/data.parquet"
+        full_path = data_dir / _PARQUET_KEY
 
         # Should raise KeyError with the relative path in the message
-        expected_key = "cache/v1/2024-01-01/2024-01-31/test/data.parquet"
-        with pytest.raises(KeyError, match=f"no remotely-cached file for {expected_key}"):
+        with pytest.raises(KeyError, match=f"no remotely-cached file for {_PARQUET_KEY}"):
             manifest.get_file_entry(full_path=full_path, data_dir=data_dir)
 
 
@@ -139,8 +156,8 @@ class TestIQBRemoteCacheSync:
         """Helper to create a mock PipelineCacheEntry."""
         entry = Mock()
         entry.data_dir = tmp_path
-        entry.data_parquet_file_path.return_value = tmp_path / "data.parquet"
-        entry.stats_json_file_path.return_value = tmp_path / "stats.json"
+        entry.data_parquet_file_path.return_value = tmp_path / _PARQUET_KEY
+        entry.stats_json_file_path.return_value = tmp_path / _STATS_KEY
         return entry
 
     def _mock_urlopen_with_content(self, json_content, parquet_content):
@@ -171,7 +188,7 @@ class TestIQBRemoteCacheSync:
             {
                 "v": 0,
                 "files": {
-                    "stats.json": {
+                    _STATS_KEY: {
                         "sha256": "abc123",
                         "url": "https://example.com/stats.json",
                     }
@@ -185,7 +202,7 @@ class TestIQBRemoteCacheSync:
 
         assert result is False
         assert "failure" in caplog.text
-        assert "no remotely-cached file for data.parquet" in caplog.text
+        assert f"no remotely-cached file for {_PARQUET_KEY}" in caplog.text
 
     def test_missing_json_entry(self, tmp_path, caplog):
         """Make sure we return False if there's no remote JSON entry."""
@@ -197,7 +214,7 @@ class TestIQBRemoteCacheSync:
             {
                 "v": 0,
                 "files": {
-                    "data.parquet": {
+                    _PARQUET_KEY: {
                         "sha256": "abc123",
                         "url": "https://example.com/data.parquet",
                     }
@@ -211,7 +228,7 @@ class TestIQBRemoteCacheSync:
 
         assert result is False
         assert "failure" in caplog.text
-        assert "no remotely-cached file for stats.json" in caplog.text
+        assert f"no remotely-cached file for {_STATS_KEY}" in caplog.text
 
     def test_download_if_not_exists(self, tmp_path):
         """Ensure that we download the file if it does not exist."""
@@ -227,11 +244,11 @@ class TestIQBRemoteCacheSync:
             {
                 "v": 0,
                 "files": {
-                    "data.parquet": {
+                    _PARQUET_KEY: {
                         "sha256": parquet_sha256,
                         "url": "https://example.com/data.parquet",
                     },
-                    "stats.json": {
+                    _STATS_KEY: {
                         "sha256": json_sha256,
                         "url": "https://example.com/stats.json",
                     },
@@ -262,6 +279,7 @@ class TestIQBRemoteCacheSync:
         entry = self._create_mock_entry(tmp_path)
 
         # Pre-create files with correct content
+        entry.stats_json_file_path().parent.mkdir(parents=True, exist_ok=True)
         entry.stats_json_file_path().write_bytes(json_content)
         entry.data_parquet_file_path().write_bytes(parquet_content)
 
@@ -270,11 +288,11 @@ class TestIQBRemoteCacheSync:
             {
                 "v": 0,
                 "files": {
-                    "data.parquet": {
+                    _PARQUET_KEY: {
                         "sha256": parquet_sha256,
                         "url": "https://example.com/data.parquet",
                     },
-                    "stats.json": {
+                    _STATS_KEY: {
                         "sha256": json_sha256,
                         "url": "https://example.com/stats.json",
                     },
@@ -304,6 +322,7 @@ class TestIQBRemoteCacheSync:
         entry = self._create_mock_entry(tmp_path)
 
         # Pre-create files with WRONG content
+        entry.stats_json_file_path().parent.mkdir(parents=True, exist_ok=True)
         entry.stats_json_file_path().write_bytes(b"wrong content")
         entry.data_parquet_file_path().write_bytes(b"wrong parquet")
 
@@ -312,11 +331,11 @@ class TestIQBRemoteCacheSync:
             {
                 "v": 0,
                 "files": {
-                    "data.parquet": {
+                    _PARQUET_KEY: {
                         "sha256": parquet_sha256,
                         "url": "https://example.com/data.parquet",
                     },
-                    "stats.json": {
+                    _STATS_KEY: {
                         "sha256": json_sha256,
                         "url": "https://example.com/stats.json",
                     },
@@ -349,11 +368,11 @@ class TestIQBRemoteCacheSync:
             {
                 "v": 0,
                 "files": {
-                    "data.parquet": {
+                    _PARQUET_KEY: {
                         "sha256": parquet_sha256,
                         "url": "https://example.com/data.parquet",
                     },
-                    "stats.json": {
+                    _STATS_KEY: {
                         "sha256": json_sha256,
                         "url": "https://example.com/stats.json",
                     },
@@ -388,11 +407,11 @@ class TestIQBRemoteCacheSync:
             {
                 "v": 0,
                 "files": {
-                    "data.parquet": {
+                    _PARQUET_KEY: {
                         "sha256": "abc123",
                         "url": "https://example.com/data.parquet",
                     },
-                    "stats.json": {
+                    _STATS_KEY: {
                         "sha256": "def456",
                         "url": "https://example.com/stats.json",
                     },
@@ -425,11 +444,11 @@ class TestIQBRemoteCacheSync:
             {
                 "v": 0,
                 "files": {
-                    "data.parquet": {
+                    _PARQUET_KEY: {
                         "sha256": wrong_sha256,
                         "url": "https://example.com/data.parquet",
                     },
-                    "stats.json": {
+                    _STATS_KEY: {
                         "sha256": wrong_sha256,
                         "url": "https://example.com/stats.json",
                     },
@@ -459,22 +478,20 @@ class TestIQBRemoteCacheSync:
         json_sha256 = _compute_test_sha256(json_content)
         parquet_sha256 = _compute_test_sha256(parquet_content)
 
-        # Create entry with nested paths that don't exist yet
-        entry = Mock()
-        entry.data_dir = tmp_path
-        entry.data_parquet_file_path.return_value = tmp_path / "nested" / "dir" / "data.parquet"
-        entry.stats_json_file_path.return_value = tmp_path / "nested" / "dir" / "stats.json"
+        # Use the standard mock entry — its cache paths are nested enough
+        # that parent directories won't exist yet
+        entry = self._create_mock_entry(tmp_path)
 
         _write_manifest(
             tmp_path,
             {
                 "v": 0,
                 "files": {
-                    "nested/dir/data.parquet": {
+                    _PARQUET_KEY: {
                         "sha256": parquet_sha256,
                         "url": "https://example.com/data.parquet",
                     },
-                    "nested/dir/stats.json": {
+                    _STATS_KEY: {
                         "sha256": json_sha256,
                         "url": "https://example.com/stats.json",
                     },
@@ -524,7 +541,7 @@ class TestLoadManifest:
         manifest_data = {
             "v": 0,
             "files": {
-                "cache/v1/20241001T000000Z/20241031T235959Z/test/data.parquet": {
+                _PARQUET_KEY: {
                     "sha256": "abc123",
                     "url": "https://example.com/data.parquet",
                 }
@@ -535,7 +552,7 @@ class TestLoadManifest:
         manifest = load_manifest(manifest_file)
         assert manifest.v == 0
         assert len(manifest.files) == 1
-        key = "cache/v1/20241001T000000Z/20241031T235959Z/test/data.parquet"
+        key = parse_entry_path(_PARQUET_KEY)
         assert manifest.files[key].sha256 == "abc123"
         assert manifest.files[key].url == "https://example.com/data.parquet"
 
@@ -549,7 +566,7 @@ class TestSaveManifest:
         original = Manifest(
             v=0,
             files={
-                "cache/v1/20241001T000000Z/20241031T235959Z/test/data.parquet": FileEntry(
+                parse_entry_path(_PARQUET_KEY): FileEntry(
                     sha256="abc123",
                     url="https://example.com/data.parquet",
                 )
@@ -574,11 +591,13 @@ class TestSaveManifest:
     def test_output_format(self, tmp_path):
         """Verify output has sorted keys, 2-space indent, trailing newline."""
         manifest_file = manifest_path_for_data_dir(tmp_path)
+        key_a = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/aaa/data.parquet")
+        key_b = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/bbb/data.parquet")
         manifest = Manifest(
             v=0,
             files={
-                "b_file": FileEntry(sha256="bbb", url="https://example.com/b"),
-                "a_file": FileEntry(sha256="aaa", url="https://example.com/a"),
+                key_b: FileEntry(sha256="bbb", url="https://example.com/b"),
+                key_a: FileEntry(sha256="aaa", url="https://example.com/a"),
             },
         )
 
@@ -588,9 +607,9 @@ class TestSaveManifest:
         # Trailing newline
         assert content.endswith("\n")
 
-        # Sorted keys: "a_file" should come before "b_file"
-        a_pos = content.index('"a_file"')
-        b_pos = content.index('"b_file"')
+        # Sorted keys: "aaa" should come before "bbb"
+        a_pos = content.index('"cache/v1/' + _TS1 + "/" + _TS2 + "/aaa/")
+        b_pos = content.index('"cache/v1/' + _TS1 + "/" + _TS2 + "/bbb/")
         assert a_pos < b_pos
 
         # 2-space indent

--- a/library/tests/iqb/ghremote/diff_test.py
+++ b/library/tests/iqb/ghremote/diff_test.py
@@ -5,7 +5,8 @@ from collections.abc import Iterator
 from pathlib import Path
 
 from iqb.ghremote.cache import FileEntry, Manifest
-from iqb.ghremote.diff import DiffEntry, DiffState, _validate_cache_path, diff
+from iqb.ghremote.diff import DiffEntry, DiffState, diff
+from iqb.ghremote.entrypath import parse_entry_path
 
 
 def _sha256(content: bytes) -> str:
@@ -24,10 +25,13 @@ def _make_cache_file(data_dir: Path, rel_path: str, content: bytes) -> Path:
 # Valid cache path components for test fixtures
 _TS1 = "20241001T000000Z"
 _TS2 = "20241031T235959Z"
-_NAME = "downloads"
-_FILE_A = f"cache/v1/{_TS1}/{_TS2}/{_NAME}/data.parquet"
-_FILE_B = f"cache/v1/{_TS1}/{_TS2}/{_NAME}/stats.json"
+_DATASET = "downloads"
+_FILE_A = f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet"
+_FILE_B = f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/stats.json"
 _FILE_C = f"cache/v1/{_TS1}/{_TS2}/uploads/data.parquet"
+_KEY_A = parse_entry_path(_FILE_A)
+_KEY_B = parse_entry_path(_FILE_B)
+_KEY_C = parse_entry_path(_FILE_C)
 
 
 class TestDiffOnlyRemote:
@@ -36,13 +40,13 @@ class TestDiffOnlyRemote:
     def test_yields_only_remote(self, tmp_path: Path):
         content = b"remote content"
         entry = FileEntry(sha256=_sha256(content), url="https://example.com/a.parquet")
-        manifest = Manifest(v=0, files={_FILE_A: entry})
+        manifest = Manifest(v=0, files={_KEY_A: entry})
 
         results = list(diff(manifest, tmp_path))
 
         assert len(results) == 1
         assert results[0] == DiffEntry(
-            file=_FILE_A,
+            file=_KEY_A,
             url="https://example.com/a.parquet",
             remote_sha256=_sha256(content),
             local_sha256=None,
@@ -51,7 +55,7 @@ class TestDiffOnlyRemote:
 
     def test_url_is_populated(self, tmp_path: Path):
         entry = FileEntry(sha256="abc123", url="https://storage.example.com/file")
-        manifest = Manifest(v=0, files={_FILE_A: entry})
+        manifest = Manifest(v=0, files={_KEY_A: entry})
 
         results = list(diff(manifest, tmp_path))
 
@@ -72,7 +76,7 @@ class TestDiffOnlyLocal:
 
         assert len(results) == 1
         assert results[0] == DiffEntry(
-            file=_FILE_A,
+            file=_KEY_A,
             url=None,
             remote_sha256=None,
             local_sha256=_sha256(content),
@@ -90,7 +94,7 @@ class TestDiffOnlyLocal:
     def test_invalid_local_files_excluded(self, tmp_path: Path):
         """Files that don't match cache path format are excluded."""
         # Create a file with invalid cache path (e.g., a .lock file)
-        _make_cache_file(tmp_path, f"cache/v1/{_TS1}/{_TS2}/{_NAME}/.lock", b"")
+        _make_cache_file(tmp_path, f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/.lock", b"")
         # Also create a file outside the cache path structure
         _make_cache_file(tmp_path, "cache/v1/not-a-timestamp/file.txt", b"data")
         manifest = Manifest(v=0, files={})
@@ -107,14 +111,14 @@ class TestDiffSha256Mismatch:
         remote_content = b"remote version"
         local_content = b"local version"
         entry = FileEntry(sha256=_sha256(remote_content), url="https://example.com/a.parquet")
-        manifest = Manifest(v=0, files={_FILE_A: entry})
+        manifest = Manifest(v=0, files={_KEY_A: entry})
         _make_cache_file(tmp_path, _FILE_A, local_content)
 
         results = list(diff(manifest, tmp_path))
 
         assert len(results) == 1
         assert results[0] == DiffEntry(
-            file=_FILE_A,
+            file=_KEY_A,
             url="https://example.com/a.parquet",
             remote_sha256=_sha256(remote_content),
             local_sha256=_sha256(local_content),
@@ -123,7 +127,7 @@ class TestDiffSha256Mismatch:
 
     def test_url_is_populated(self, tmp_path: Path):
         entry = FileEntry(sha256="0" * 64, url="https://example.com/file")
-        manifest = Manifest(v=0, files={_FILE_A: entry})
+        manifest = Manifest(v=0, files={_KEY_A: entry})
         _make_cache_file(tmp_path, _FILE_A, b"different")
 
         results = list(diff(manifest, tmp_path))
@@ -137,14 +141,14 @@ class TestDiffMatching:
     def test_yields_matching(self, tmp_path: Path):
         content = b"same content"
         entry = FileEntry(sha256=_sha256(content), url="https://example.com/a.parquet")
-        manifest = Manifest(v=0, files={_FILE_A: entry})
+        manifest = Manifest(v=0, files={_KEY_A: entry})
         _make_cache_file(tmp_path, _FILE_A, content)
 
         results = list(diff(manifest, tmp_path))
 
         assert len(results) == 1
         assert results[0] == DiffEntry(
-            file=_FILE_A,
+            file=_KEY_A,
             url="https://example.com/a.parquet",
             remote_sha256=_sha256(content),
             local_sha256=_sha256(content),
@@ -158,13 +162,13 @@ class TestDiffAcceptPredicate:
     def test_excludes_manifest_entries(self, tmp_path: Path):
         entry_a = FileEntry(sha256="abc", url="https://example.com/a")
         entry_b = FileEntry(sha256="def", url="https://example.com/b")
-        manifest = Manifest(v=0, files={_FILE_A: entry_a, _FILE_B: entry_b})
+        manifest = Manifest(v=0, files={_KEY_A: entry_a, _KEY_B: entry_b})
 
         # Only accept stats.json paths
-        results = list(diff(manifest, tmp_path, acceptp=lambda p: p.endswith("stats.json")))
+        results = list(diff(manifest, tmp_path, acceptp=lambda p: p.filename == "stats.json"))
 
         assert len(results) == 1
-        assert results[0].file == _FILE_B
+        assert results[0].file == _KEY_B
 
     def test_excludes_local_entries(self, tmp_path: Path):
         _make_cache_file(tmp_path, _FILE_A, b"parquet data")
@@ -172,15 +176,15 @@ class TestDiffAcceptPredicate:
         manifest = Manifest(v=0, files={})
 
         # Only accept data.parquet paths
-        results = list(diff(manifest, tmp_path, acceptp=lambda p: p.endswith("data.parquet")))
+        results = list(diff(manifest, tmp_path, acceptp=lambda p: p.filename == "data.parquet"))
 
         assert len(results) == 1
-        assert results[0].file == _FILE_A
+        assert results[0].file == _KEY_A
 
     def test_applies_to_both_manifest_and_local(self, tmp_path: Path):
         content_a = b"content a"
         entry_a = FileEntry(sha256=_sha256(content_a), url="https://example.com/a")
-        manifest = Manifest(v=0, files={_FILE_A: entry_a})
+        manifest = Manifest(v=0, files={_KEY_A: entry_a})
         _make_cache_file(tmp_path, _FILE_A, content_a)
         _make_cache_file(tmp_path, _FILE_B, b"local only json")
 
@@ -205,9 +209,9 @@ class TestDiffOrdering:
     """Manifest entries come before local-only, both sorted by file."""
 
     def test_manifest_before_local_only(self, tmp_path: Path):
-        # _FILE_C (uploads/data.parquet) is in manifest but not local
+        # _KEY_C (uploads/data.parquet) is in manifest but not local
         entry = FileEntry(sha256="abc", url="https://example.com/c")
-        manifest = Manifest(v=0, files={_FILE_C: entry})
+        manifest = Manifest(v=0, files={_KEY_C: entry})
         # _FILE_A (downloads/data.parquet) is local but not in manifest
         _make_cache_file(tmp_path, _FILE_A, b"local only")
 
@@ -216,22 +220,22 @@ class TestDiffOrdering:
         assert len(results) == 2
         # Manifest entry first (ONLY_REMOTE), then local-only (ONLY_LOCAL)
         assert results[0].state == DiffState.ONLY_REMOTE
-        assert results[0].file == _FILE_C
+        assert results[0].file == _KEY_C
         assert results[1].state == DiffState.ONLY_LOCAL
-        assert results[1].file == _FILE_A
+        assert results[1].file == _KEY_A
 
     def test_sorted_within_phases(self, tmp_path: Path):
         # Two manifest entries in reverse alphabetical order
         entry_b = FileEntry(sha256="b", url="https://example.com/b")
         entry_a = FileEntry(sha256="a", url="https://example.com/a")
-        manifest = Manifest(v=0, files={_FILE_B: entry_b, _FILE_A: entry_a})
+        manifest = Manifest(v=0, files={_KEY_B: entry_b, _KEY_A: entry_a})
 
         results = list(diff(manifest, tmp_path))
 
         assert len(results) == 2
-        # Should be sorted: _FILE_A (downloads/data.parquet) before _FILE_B (downloads/stats.json)
-        assert results[0].file == _FILE_A
-        assert results[1].file == _FILE_B
+        # Should be sorted: _KEY_A (downloads/data.parquet) before _KEY_B (downloads/stats.json)
+        assert results[0].file == _KEY_A
+        assert results[1].file == _KEY_B
 
     def test_sorted_local_only(self, tmp_path: Path):
         _make_cache_file(tmp_path, _FILE_C, b"c")
@@ -241,8 +245,8 @@ class TestDiffOrdering:
         results = list(diff(manifest, tmp_path))
 
         assert len(results) == 2
-        assert results[0].file == _FILE_A
-        assert results[1].file == _FILE_C
+        assert results[0].file == _KEY_A
+        assert results[1].file == _KEY_C
 
 
 class TestDiffIsIterator:
@@ -256,107 +260,3 @@ class TestDiffIsIterator:
         assert isinstance(result, Iterator)
         # Should not be a list or tuple
         assert not isinstance(result, (list, tuple))
-
-
-class TestDiffInvalidManifestKeys:
-    """Invalid manifest keys are ignored for safety."""
-
-    def test_traversal_manifest_key_is_ignored(self, tmp_path: Path):
-        manifest = Manifest(
-            v=0,
-            files={
-                "../../etc/passwd": FileEntry(
-                    sha256="0" * 64,
-                    url="https://example.com/passwd",
-                )
-            },
-        )
-
-        results = list(diff(manifest, tmp_path))
-
-        assert results == []
-
-    def test_dotdot_inside_cache_path_is_ignored(self, tmp_path: Path):
-        manifest = Manifest(
-            v=0,
-            files={
-                f"cache/v1/{_TS1}/{_TS2}/{_NAME}/../data.parquet": FileEntry(
-                    sha256="0" * 64,
-                    url="https://example.com/a",
-                )
-            },
-        )
-
-        results = list(diff(manifest, tmp_path))
-
-        assert results == []
-
-    def test_mixed_valid_and_invalid_manifest_keys(self, tmp_path: Path):
-        content = b"remote content"
-        manifest = Manifest(
-            v=0,
-            files={
-                "../../etc/passwd": FileEntry(
-                    sha256="0" * 64,
-                    url="https://example.com/passwd",
-                ),
-                _FILE_A: FileEntry(
-                    sha256=_sha256(content),
-                    url="https://example.com/a.parquet",
-                ),
-            },
-        )
-
-        results = list(diff(manifest, tmp_path))
-
-        assert len(results) == 1
-        assert results[0].file == _FILE_A
-        assert results[0].state == DiffState.ONLY_REMOTE
-
-
-class TestValidateCachePath:
-    """Tests for _validate_cache_path covering all branches."""
-
-    _VALID = f"cache/v1/{_TS1}/{_TS2}/{_NAME}/data.parquet"
-
-    def test_valid_data_parquet(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/{_TS2}/{_NAME}/data.parquet") is True
-
-    def test_valid_stats_json(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/{_TS2}/{_NAME}/stats.json") is True
-
-    def test_too_few_components(self):
-        assert _validate_cache_path("cache/v1") is False
-
-    def test_too_many_components(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/{_TS2}/{_NAME}/extra/data.parquet") is False
-
-    def test_wrong_first_component(self):
-        assert _validate_cache_path(f"notcache/v1/{_TS1}/{_TS2}/{_NAME}/data.parquet") is False
-
-    def test_wrong_second_component(self):
-        assert _validate_cache_path(f"cache/v2/{_TS1}/{_TS2}/{_NAME}/data.parquet") is False
-
-    def test_invalid_first_timestamp(self):
-        assert _validate_cache_path(f"cache/v1/not-a-ts/{_TS2}/{_NAME}/data.parquet") is False
-
-    def test_invalid_second_timestamp(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/not-a-ts/{_NAME}/data.parquet") is False
-
-    def test_name_with_uppercase(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/{_TS2}/Downloads/data.parquet") is False
-
-    def test_name_with_hyphen(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/{_TS2}/my-name/data.parquet") is False
-
-    def test_name_with_underscore(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/{_TS2}/my_name/data.parquet") is True
-
-    def test_invalid_filename(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/{_TS2}/{_NAME}/other.txt") is False
-
-    def test_lock_file(self):
-        assert _validate_cache_path(f"cache/v1/{_TS1}/{_TS2}/{_NAME}/.lock") is False
-
-    def test_empty_string(self):
-        assert _validate_cache_path("") is False

--- a/library/tests/iqb/ghremote/entrypath_test.py
+++ b/library/tests/iqb/ghremote/entrypath_test.py
@@ -1,0 +1,105 @@
+"""Tests for the iqb.ghremote.entrypath module."""
+
+import pytest
+
+from iqb.ghremote.entrypath import ManifestEntryPath, parse_entry_path
+
+_TS1 = "20241001T000000Z"
+_TS2 = "20241031T235959Z"
+_DATASET = "downloads"
+
+
+class TestParseEntryPath:
+    """Tests for parse_entry_path covering all validation branches."""
+
+    def test_valid_data_parquet(self):
+        result = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet")
+        assert result == ManifestEntryPath(
+            start=_TS1, end=_TS2, dataset=_DATASET, filename="data.parquet"
+        )
+
+    def test_valid_stats_json(self):
+        result = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/stats.json")
+        assert result.filename == "stats.json"
+
+    def test_too_few_components(self):
+        with pytest.raises(ValueError, match="expected 6 path components"):
+            parse_entry_path("cache/v1")
+
+    def test_too_many_components(self):
+        with pytest.raises(ValueError, match="expected 6 path components"):
+            parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/extra/data.parquet")
+
+    def test_wrong_first_component(self):
+        with pytest.raises(ValueError, match="first component must be 'cache'"):
+            parse_entry_path(f"notcache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet")
+
+    def test_wrong_second_component(self):
+        with pytest.raises(ValueError, match="second component must be 'v1'"):
+            parse_entry_path(f"cache/v2/{_TS1}/{_TS2}/{_DATASET}/data.parquet")
+
+    def test_invalid_first_timestamp(self):
+        with pytest.raises(ValueError, match="invalid start timestamp"):
+            parse_entry_path(f"cache/v1/not-a-ts/{_TS2}/{_DATASET}/data.parquet")
+
+    def test_invalid_second_timestamp(self):
+        with pytest.raises(ValueError, match="invalid end timestamp"):
+            parse_entry_path(f"cache/v1/{_TS1}/not-a-ts/{_DATASET}/data.parquet")
+
+    def test_name_with_uppercase(self):
+        with pytest.raises(ValueError, match="invalid dataset"):
+            parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/Downloads/data.parquet")
+
+    def test_name_with_hyphen(self):
+        with pytest.raises(ValueError, match="invalid dataset"):
+            parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/my-name/data.parquet")
+
+    def test_name_with_underscore(self):
+        result = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/my_name/data.parquet")
+        assert result.dataset == "my_name"
+
+    def test_invalid_filename(self):
+        with pytest.raises(ValueError, match="invalid filename"):
+            parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/other.txt")
+
+    def test_lock_file(self):
+        with pytest.raises(ValueError, match="invalid filename"):
+            parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/.lock")
+
+    def test_empty_string(self):
+        with pytest.raises(ValueError, match="expected 6 path components"):
+            parse_entry_path("")
+
+
+class TestManifestEntryPathStr:
+    """Tests for __str__ round-tripping."""
+
+    def test_round_trip(self):
+        raw = f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet"
+        result = parse_entry_path(raw)
+        assert str(result) == raw
+
+    def test_round_trip_stats(self):
+        raw = f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/stats.json"
+        result = parse_entry_path(raw)
+        assert str(result) == raw
+
+
+class TestManifestEntryPathAsKey:
+    """ManifestEntryPath must be usable as a dict key."""
+
+    def test_hashable(self):
+        path = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet")
+        d = {path: "value"}
+        assert d[path] == "value"
+
+    def test_equal_instances_same_hash(self):
+        a = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet")
+        b = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet")
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_different_instances_different(self):
+        a = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/data.parquet")
+        b = parse_entry_path(f"cache/v1/{_TS1}/{_TS2}/{_DATASET}/stats.json")
+        assert a != b

--- a/prototype/pages/IQB_Map.py
+++ b/prototype/pages/IQB_Map.py
@@ -10,7 +10,7 @@ Data sources:
 """
 
 import json
-import re
+
 from datetime import datetime
 from pathlib import Path
 from urllib.request import urlopen
@@ -19,9 +19,13 @@ import pandas as pd
 import plotly.graph_objects as go
 import pycountry
 import streamlit as st
-from dacite import from_dict
 from iqb import IQBCache, IQBDatasetGranularity
-from iqb.ghremote.cache import IQBRemoteCache, Manifest, data_dir_or_default
+from iqb.ghremote.cache import (
+    IQBRemoteCache,
+    Manifest,
+    data_dir_or_default,
+    load_manifest_from_dict,
+)
 from plotly.subplots import make_subplots
 from session_state import initialize_app_state
 from visualizations.sunburst_data import (
@@ -161,7 +165,7 @@ class GitHubURLRemoteCache(IQBRemoteCache):
     def _load_manifest_from_url(self, url: str) -> Manifest:
         with urlopen(url) as resp:
             data = json.load(resp)
-        return from_dict(Manifest, data)
+        return load_manifest_from_dict(data)
 
 
 # --- Session State ---
@@ -298,18 +302,15 @@ def get_available_periods(_manifest_files: tuple) -> list[tuple[str, str, str]]:
     """Parse available periods from manifest files."""
     periods = set()
     for key in _manifest_files:
-        match = re.match(
-            r"cache/v1/(\d{4})(\d{2})(\d{2})T.*/(\d{4})(\d{2})(\d{2})T.*/downloads_by_country_city/",
-            key,
-        )
-        if match:
-            sy, sm, sd, ey, em, ed = match.groups()
-            start_date = f"{sy}-{sm}-{sd}"
-            end_date = f"{ey}-{em}-{ed}"
-            start_label = datetime.strptime(start_date, "%Y-%m-%d").strftime("%b %Y")
-            end_label = datetime.strptime(end_date, "%Y-%m-%d").strftime("%b %Y")
-            label = f"{start_label} - {end_label}"
-            periods.add((label, start_date, end_date))
+        if key.dataset != "downloads_by_country_city":
+            continue
+        # Timestamps are in the form YYYYMMDDTHHMMSSZ
+        start_date = f"{key.start[:4]}-{key.start[4:6]}-{key.start[6:8]}"
+        end_date = f"{key.end[:4]}-{key.end[4:6]}-{key.end[6:8]}"
+        start_label = datetime.strptime(start_date, "%Y-%m-%d").strftime("%b %Y")
+        end_label = datetime.strptime(end_date, "%Y-%m-%d").strftime("%b %Y")
+        label = f"{start_label} - {end_label}"
+        periods.add((label, start_date, end_date))
     return sorted(periods, key=lambda x: x[1], reverse=True)
 
 


### PR DESCRIPTION
This diff modifies ghremote so that we parse, rather than validating, the manifest keys. In addition to being the correct approach when processing potentially untrusted data, this change opens up the possibility of filtering the manifest entries, and only using a subset.

Part of https://github.com/m-lab/iqb/issues/192.