### PR TITLE
feat(ghremote): allow for remote manifests

### DIFF
--- a/library/src/iqb/ghremote/__init__.py
+++ b/library/src/iqb/ghremote/__init__.py
@@ -29,6 +29,7 @@ from .cache import (
     Manifest,
     load_manifest,
     load_manifest_from_dict,
+    load_manifest_from_url,
     manifest_path_for_data_dir,
     save_manifest,
 )
@@ -51,6 +52,7 @@ __all__ = [
     "diff",
     "load_manifest",
     "load_manifest_from_dict",
+    "load_manifest_from_url",
     "manifest_path_for_data_dir",
     "parse_entry_path",
     "save_manifest",

--- a/library/src/iqb/ghremote/cache.py
+++ b/library/src/iqb/ghremote/cache.py
@@ -135,6 +135,13 @@ def load_manifest(manifest_file: Path) -> Manifest:
     return load_manifest_from_dict(data)
 
 
+def load_manifest_from_url(url: str) -> Manifest:
+    """Load manifest from the given URL."""
+    with urlopen(url) as resp:
+        data = json.load(resp)
+    return load_manifest_from_dict(data)
+
+
 def manifest_path_for_data_dir(data_dir: Path) -> Path:
     """Return the manifest path under the given data directory."""
     return data_dir / "state" / "ghremote" / "manifest.json"
@@ -165,10 +172,14 @@ class IQBRemoteCache:
         self,
         *,
         data_dir: str | Path | None = None,
+        manifest: Manifest | None = None,
     ) -> None:
         self.data_dir = data_dir_or_default(data_dir)
-        manifest_path = manifest_path_for_data_dir(self.data_dir)
-        self.manifest = load_manifest(manifest_path)
+        if manifest is not None:
+            self.manifest = manifest
+        else:
+            manifest_path = manifest_path_for_data_dir(self.data_dir)
+            self.manifest = load_manifest(manifest_path)
 
     def sync(self, entry: PipelineCacheEntry) -> bool:
         """

--- a/library/tests/iqb/ghremote/cache_test.py
+++ b/library/tests/iqb/ghremote/cache_test.py
@@ -14,6 +14,7 @@ from iqb.ghremote.cache import (
     IQBRemoteCache,
     Manifest,
     load_manifest,
+    load_manifest_from_url,
     manifest_path_for_data_dir,
     save_manifest,
 )
@@ -99,6 +100,96 @@ class TestIQBRemoteCacheLoadManifest:
 
         assert manifest.v == 0
         assert len(manifest.files) == 0
+
+
+class TestLoadManifestFromUrl:
+    """Tests for load_manifest_from_url."""
+
+    def _mock_urlopen(self, manifest_data):
+        response = Mock()
+        response.read.return_value = json.dumps(manifest_data).encode()
+        response.__enter__ = Mock(return_value=response)
+        response.__exit__ = Mock(return_value=False)
+        return response
+
+    def test_loads_valid_manifest(self):
+        manifest_data = {
+            "v": 0,
+            "files": {
+                _PARQUET_KEY: {
+                    "sha256": "abc123",
+                    "url": "https://example.com/data.parquet",
+                }
+            },
+        }
+        with patch("iqb.ghremote.cache.urlopen", return_value=self._mock_urlopen(manifest_data)):
+            manifest = load_manifest_from_url("https://example.com/manifest.json")
+
+        assert manifest.v == 0
+        assert len(manifest.files) == 1
+        key = parse_entry_path(_PARQUET_KEY)
+        assert manifest.files[key].sha256 == "abc123"
+
+    def test_empty_manifest(self):
+        manifest_data = {"v": 0, "files": {}}
+        with patch("iqb.ghremote.cache.urlopen", return_value=self._mock_urlopen(manifest_data)):
+            manifest = load_manifest_from_url("https://example.com/manifest.json")
+
+        assert manifest.v == 0
+        assert len(manifest.files) == 0
+
+    def test_url_error_propagates(self):
+        with patch("iqb.ghremote.cache.urlopen", side_effect=URLError("not found")):
+            with pytest.raises(URLError):
+                load_manifest_from_url("https://example.com/missing.json")
+
+
+class TestIQBRemoteCacheWithManifest:
+    """Tests for IQBRemoteCache with a pre-loaded manifest."""
+
+    def test_uses_provided_manifest(self, tmp_path):
+        manifest = Manifest(
+            v=0,
+            files={
+                parse_entry_path(_PARQUET_KEY): FileEntry(
+                    sha256="abc123", url="https://example.com/data.parquet"
+                )
+            },
+        )
+        cache = IQBRemoteCache(data_dir=tmp_path, manifest=manifest)
+
+        assert cache.manifest is manifest
+        assert len(cache.manifest.files) == 1
+
+    def test_ignores_disk_manifest_when_provided(self, tmp_path):
+        _write_manifest(
+            tmp_path,
+            {
+                "v": 0,
+                "files": {
+                    _PARQUET_KEY: {"sha256": "on_disk", "url": "https://example.com/disk"},
+                    _STATS_KEY: {"sha256": "on_disk", "url": "https://example.com/disk"},
+                },
+            },
+        )
+        provided = Manifest(v=0, files={})
+        cache = IQBRemoteCache(data_dir=tmp_path, manifest=provided)
+
+        assert len(cache.manifest.files) == 0
+
+    def test_falls_back_to_disk_when_not_provided(self, tmp_path):
+        _write_manifest(
+            tmp_path,
+            {
+                "v": 0,
+                "files": {
+                    _PARQUET_KEY: {"sha256": "abc", "url": "https://example.com/f"},
+                },
+            },
+        )
+        cache = IQBRemoteCache(data_dir=tmp_path)
+
+        assert len(cache.manifest.files) == 1
 
 
 class TestManifestGetFileEntry:

--- a/library/tests/iqb/ghremote/cache_test.py
+++ b/library/tests/iqb/ghremote/cache_test.py
@@ -139,9 +139,11 @@ class TestLoadManifestFromUrl:
         assert len(manifest.files) == 0
 
     def test_url_error_propagates(self):
-        with patch("iqb.ghremote.cache.urlopen", side_effect=URLError("not found")):
-            with pytest.raises(URLError):
-                load_manifest_from_url("https://example.com/missing.json")
+        with (
+            patch("iqb.ghremote.cache.urlopen", side_effect=URLError("not found")),
+            pytest.raises(URLError),
+        ):
+            load_manifest_from_url("https://example.com/missing.json")
 
 
 class TestIQBRemoteCacheWithManifest:

--- a/prototype/pages/IQB_Map.py
+++ b/prototype/pages/IQB_Map.py
@@ -13,19 +13,13 @@ import json
 
 from datetime import datetime
 from pathlib import Path
-from urllib.request import urlopen
 
 import pandas as pd
 import plotly.graph_objects as go
 import pycountry
 import streamlit as st
-from iqb import IQBCache, IQBDatasetGranularity
-from iqb.ghremote.cache import (
-    IQBRemoteCache,
-    Manifest,
-    data_dir_or_default,
-    load_manifest_from_dict,
-)
+from iqb import IQBCache, IQBDatasetGranularity, IQBRemoteCache
+from iqb.ghremote import Manifest, load_manifest_from_url
 from plotly.subplots import make_subplots
 from session_state import initialize_app_state
 from visualizations.sunburst_data import (
@@ -154,20 +148,6 @@ COUNTRY_COORDS = {
 }
 
 
-# --- Remote Cache ---
-class GitHubURLRemoteCache(IQBRemoteCache):
-    """Remote cache that fetches manifest from a URL."""
-
-    def __init__(self, manifest_url: str, data_dir=None):
-        self.data_dir = data_dir_or_default(data_dir)
-        self.manifest = self._load_manifest_from_url(manifest_url)
-
-    def _load_manifest_from_url(self, url: str) -> Manifest:
-        with urlopen(url) as resp:
-            data = json.load(resp)
-        return load_manifest_from_dict(data)
-
-
 # --- Session State ---
 if "app_state" not in st.session_state:
     st.session_state.app_state = initialize_app_state()
@@ -293,7 +273,8 @@ def update_state_from_cache(state, metrics: dict, percentile: str):
 # --- Cache Functions ---
 @st.cache_resource
 def get_iqb_cache() -> IQBCache:
-    remote_cache = GitHubURLRemoteCache(MANIFEST_URL)
+    manifest = load_manifest_from_url(MANIFEST_URL)
+    remote_cache = IQBRemoteCache(manifest=manifest)
     return IQBCache(remote_cache=remote_cache)
 
 


### PR DESCRIPTION
Merge into the library code from the prototype that loaded the manifest from a URL, then arrange for IQBRemoteCache to either use an already existing Manifest (which supports this new use case) or read from the cache dir (which supports the previous use case).

Closes https://github.com/m-lab/iqb/issues/195