### PR TITLE
feat: allow programmatic, selective cache pulls

### DIFF
--- a/library/src/iqb/cli/cache_pull.py
+++ b/library/src/iqb/cli/cache_pull.py
@@ -1,110 +1,10 @@
 """Cache pull command."""
 
-# TODO(bassosimone): this download logic overlaps with ghremote/cache.py;
-# consider unifying into a shared helper once both implementations stabilise.
-
-import hashlib
-import json
-import os
-import threading
-import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
 import click
-import requests
-from rich.progress import (
-    BarColumn,
-    DownloadColumn,
-    Progress,
-    TextColumn,
-    TransferSpeedColumn,
-)
 
-from ..ghremote import DiffState, diff, load_manifest, manifest_path_for_data_dir
-from ..ghremote.diff import DiffEntry
-from ..ghremote.entrypath import ManifestEntryPath
 from ..pipeline.cache import data_dir_or_default
+from ..scripting import iqb_cache_pull
 from .cache import cache
-
-_thread_local = threading.local()
-
-
-def _get_session() -> requests.Session:
-    """Return a per-thread requests.Session for connection reuse."""
-    if not hasattr(_thread_local, "session"):
-        _thread_local.session = requests.Session()
-    return _thread_local.session
-
-
-def _short_name(path: ManifestEntryPath) -> str:
-    """Extract a short display name from a manifest entry path."""
-    return f"{path.dataset}/{path.filename}"
-
-
-def _now() -> str:
-    """Return the current time formatted for metrics spans."""
-    return datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %z")
-
-
-def _download_one(
-    entry: DiffEntry,
-    data_dir: Path,
-    progress: Progress,
-) -> dict[str, object]:
-    """Download a single file, verify SHA256, atomic-replace. Returns a metrics span."""
-    t0 = _now()
-    worker_id = threading.get_ident()
-    total_bytes = 0
-    content_length: int | None = None
-    ok = True
-    error: str | None = None
-    assert entry.url is not None
-    assert entry.remote_sha256 is not None
-    dest = data_dir / Path(str(entry.file))
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    task_id = progress.add_task(_short_name(entry.file), total=None)
-    try:
-        with TemporaryDirectory(dir=dest.parent) as tmp_dir:
-            tmp_file = Path(tmp_dir) / dest.name
-            session = _get_session()
-            resp = session.get(entry.url, stream=True)
-            resp.raise_for_status()
-            cl = resp.headers.get("Content-Length")
-            if cl is not None:
-                content_length = int(cl)
-                progress.update(task_id, total=content_length)
-            sha256 = hashlib.sha256()
-            with open(tmp_file, "wb") as fp:
-                for chunk in resp.iter_content(chunk_size=8192):
-                    fp.write(chunk)
-                    sha256.update(chunk)
-                    total_bytes += len(chunk)
-                    progress.update(task_id, advance=len(chunk))
-            got = sha256.hexdigest()
-            if got != entry.remote_sha256:
-                raise ValueError(
-                    f"SHA256 mismatch for {str(entry.file)}: expected {entry.remote_sha256}, got {got}"
-                )
-            os.replace(tmp_file, dest)
-    except Exception as exc:
-        ok = False
-        error = str(exc)
-    finally:
-        progress.remove_task(task_id)
-    return {
-        "t0": t0,
-        "t": _now(),
-        "worker_id": worker_id,
-        "file": str(entry.file),
-        "url": entry.url,
-        "content_length": content_length,
-        "bytes": total_bytes,
-        "ok": ok,
-        "error": error,
-    }
 
 
 @cache.command()
@@ -133,65 +33,26 @@ def pull(
     before: str | None,
 ) -> None:
     """Download missing cache files from the manifest."""
-    resolved = data_dir_or_default(data_dir)
-    manifest_path = manifest_path_for_data_dir(resolved)
-    manifest = load_manifest(manifest_path)
-    manifest = manifest.filter(datasets=datasets, files=files, after=after, before=before)
+    result = iqb_cache_pull.run(
+        data_dir=data_dir,
+        datasets=datasets,
+        files=files,
+        after=after,
+        before=before,
+        force=force,
+        jobs=jobs,
+    )
 
-    # Collect entries to download
-    targets: list[DiffEntry] = []
-    for entry in diff(manifest, resolved):
-        if entry.state == DiffState.ONLY_REMOTE:
-            targets.append(entry)
-        elif entry.state == DiffState.SHA256_MISMATCH and force:
-            targets.append(entry)
-
-    if not targets:
+    if result is None:
         click.echo("Nothing to download.")
         return
 
-    failed: list[tuple[str, str]] = []
-    spans: list[dict[str, object]] = []
-    t0 = time.monotonic()
-    with (
-        Progress(
-            TextColumn("{task.description}"),
-            BarColumn(),
-            DownloadColumn(),
-            TransferSpeedColumn(),
-        ) as progress,
-        ThreadPoolExecutor(max_workers=jobs) as pool,
-    ):
-        futures = {
-            pool.submit(_download_one, entry, resolved, progress): entry for entry in targets
-        }
-        for future in as_completed(futures):
-            entry = futures[future]
-            try:
-                span = future.result()
-                spans.append(span)
-                if not span["ok"]:
-                    failed.append((str(span["file"]), str(span["error"] or "unknown")))
-            except Exception as exc:
-                # Defensive: bug in _download_one itself
-                failed.append((str(entry.file), str(exc)))
-    elapsed = time.monotonic() - t0
+    resolved = data_dir_or_default(data_dir)
+    click.echo(f"Downloaded {result.ok}/{result.total} file(s) in {result.elapsed:.1f}s.")
+    click.echo(f"Detailed logs: {result.log_file.relative_to(resolved)}")
 
-    # Write metrics
-    log_dir = resolved / "state" / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    now = datetime.now().astimezone().strftime("%Y%m%dT%H%M%S")
-    log_file = log_dir / f"{now}_{time.time_ns()}_pull.jsonl"
-    with open(log_file, "w", encoding="utf-8") as fp:
-        for span in spans:
-            fp.write(json.dumps(span) + "\n")
-
-    ok_count = len(targets) - len(failed)
-    click.echo(f"Downloaded {ok_count}/{len(targets)} file(s) in {elapsed:.1f}s.")
-    click.echo(f"Detailed logs: {log_file.relative_to(resolved)}")
-
-    if failed:
-        click.echo(f"{len(failed)} download(s) failed:", err=True)
-        for file, reason in failed:
+    if result.failed:
+        click.echo(f"{len(result.failed)} download(s) failed:", err=True)
+        for file, reason in result.failed:
             click.echo(f"  {file}: {reason}", err=True)
         raise SystemExit(1)

--- a/library/src/iqb/cli/cache_push.py
+++ b/library/src/iqb/cli/cache_push.py
@@ -1,7 +1,7 @@
 """Cache push command."""
 
 # TODO(bassosimone): cache_pull has been refactored so that the core logic
-# lives in scripting.iqb_cache_pull and the CLI is a thin wrapper.  We could
+# lives in scripting.iqb_cache_pull and the CLI is a thin wrapper. We could
 # do the same here, but there is no known use case for pushing cache entries
 # programmatically yet, so the refactoring is deferred until needed.
 

--- a/library/src/iqb/cli/cache_push.py
+++ b/library/src/iqb/cli/cache_push.py
@@ -1,5 +1,10 @@
 """Cache push command."""
 
+# TODO(bassosimone): cache_pull has been refactored so that the core logic
+# lives in scripting.iqb_cache_pull and the CLI is a thin wrapper.  We could
+# do the same here, but there is no known use case for pushing cache entries
+# programmatically yet, so the refactoring is deferred until needed.
+
 import time
 from pathlib import Path
 

--- a/library/src/iqb/scripting/iqb_cache_pull.py
+++ b/library/src/iqb/scripting/iqb_cache_pull.py
@@ -1,0 +1,207 @@
+"""Optional scripting extensions to pull cache entries."""
+
+# TODO(bassosimone): this download logic overlaps with ghremote/cache.py;
+# consider unifying into a shared helper once both implementations stabilise.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import requests
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    TextColumn,
+    TransferSpeedColumn,
+)
+
+from ..ghremote import DiffState, Manifest, diff, load_manifest, manifest_path_for_data_dir
+from ..ghremote.diff import DiffEntry
+from ..ghremote.entrypath import ManifestEntryPath
+from ..pipeline.cache import data_dir_or_default
+from .iqb_logging import log
+
+_thread_local = threading.local()
+
+
+def _get_session() -> requests.Session:
+    """Return a per-thread requests.Session for connection reuse."""
+    if not hasattr(_thread_local, "session"):
+        _thread_local.session = requests.Session()
+    return _thread_local.session
+
+
+def _short_name(path: ManifestEntryPath) -> str:
+    """Extract a short display name from a manifest entry path."""
+    return f"{path.dataset}/{path.filename}"
+
+
+def _now() -> str:
+    """Return the current time formatted for metrics spans."""
+    return datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %z")
+
+
+def _download_one(
+    entry: DiffEntry,
+    data_dir: Path,
+    progress: Progress,
+) -> dict[str, object]:
+    """Download a single file, verify SHA256, atomic-replace. Returns a metrics span."""
+    t0 = _now()
+    worker_id = threading.get_ident()
+    total_bytes = 0
+    content_length: int | None = None
+    ok = True
+    error: str | None = None
+    assert entry.url is not None
+    assert entry.remote_sha256 is not None
+    dest = data_dir / Path(str(entry.file))
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    task_id = progress.add_task(_short_name(entry.file), total=None)
+    try:
+        with TemporaryDirectory(dir=dest.parent) as tmp_dir:
+            tmp_file = Path(tmp_dir) / dest.name
+            session = _get_session()
+            resp = session.get(entry.url, stream=True)
+            resp.raise_for_status()
+            cl = resp.headers.get("Content-Length")
+            if cl is not None:
+                content_length = int(cl)
+                progress.update(task_id, total=content_length)
+            sha256 = hashlib.sha256()
+            with open(tmp_file, "wb") as fp:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    fp.write(chunk)
+                    sha256.update(chunk)
+                    total_bytes += len(chunk)
+                    progress.update(task_id, advance=len(chunk))
+            got = sha256.hexdigest()
+            if got != entry.remote_sha256:
+                raise ValueError(
+                    f"SHA256 mismatch for {str(entry.file)}: expected {entry.remote_sha256}, got {got}"
+                )
+            os.replace(tmp_file, dest)
+    except Exception as exc:
+        ok = False
+        error = str(exc)
+    finally:
+        progress.remove_task(task_id)
+    return {
+        "t0": t0,
+        "t": _now(),
+        "worker_id": worker_id,
+        "file": str(entry.file),
+        "url": entry.url,
+        "content_length": content_length,
+        "bytes": total_bytes,
+        "ok": ok,
+        "error": error,
+    }
+
+
+@dataclass(frozen=True, kw_only=True)
+class PullResult:
+    """Result of a cache pull operation."""
+
+    total: int
+    ok: int
+    failed: list[tuple[str, str]] = field(default_factory=list)
+    log_file: Path
+    elapsed: float
+
+
+def run(
+    *,
+    data_dir: str | Path | None = None,
+    manifest: Manifest | None = None,
+    datasets: tuple[str, ...] = (),
+    files: tuple[str, ...] = (),
+    after: str | None = None,
+    before: str | None = None,
+    force: bool = False,
+    jobs: int = 8,
+) -> PullResult | None:
+    """Pull cache entries from the remote manifest.
+
+    When *manifest* is provided it is used directly; otherwise the manifest
+    is loaded from disk under *data_dir*.
+
+    Returns ``None`` when there is nothing to download.
+    """
+    resolved = data_dir_or_default(data_dir)
+    if manifest is None:
+        manifest_path = manifest_path_for_data_dir(resolved)
+        manifest = load_manifest(manifest_path)
+    manifest = manifest.filter(datasets=datasets, files=files, after=after, before=before)
+
+    # Collect entries to download
+    targets: list[DiffEntry] = []
+    for entry in diff(manifest, resolved):
+        if entry.state == DiffState.ONLY_REMOTE:
+            targets.append(entry)
+        elif entry.state == DiffState.SHA256_MISMATCH and force:
+            targets.append(entry)
+
+    if not targets:
+        log.info("nothing to download")
+        return None
+
+    failed: list[tuple[str, str]] = []
+    spans: list[dict[str, object]] = []
+    t0 = time.monotonic()
+    with (
+        Progress(
+            TextColumn("{task.description}"),
+            BarColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+        ) as progress,
+        ThreadPoolExecutor(max_workers=jobs) as pool,
+    ):
+        futures = {
+            pool.submit(_download_one, entry, resolved, progress): entry for entry in targets
+        }
+        for future in as_completed(futures):
+            entry = futures[future]
+            try:
+                span = future.result()
+                spans.append(span)
+                if not span["ok"]:
+                    failed.append((str(span["file"]), str(span["error"] or "unknown")))
+            except Exception as exc:
+                # Defensive: bug in _download_one itself
+                failed.append((str(entry.file), str(exc)))
+    elapsed = time.monotonic() - t0
+
+    # Write metrics
+    log_dir = resolved / "state" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now().astimezone().strftime("%Y%m%dT%H%M%S")
+    log_file = log_dir / f"{now}_{time.time_ns()}_pull.jsonl"
+    with open(log_file, "w", encoding="utf-8") as fp:
+        for span in spans:
+            fp.write(json.dumps(span) + "\n")
+
+    ok_count = len(targets) - len(failed)
+    log.info("downloaded %d/%d file(s) in %.1fs", ok_count, len(targets), elapsed)
+    if failed:
+        for file, reason in failed:
+            log.warning("failed: %s: %s", file, reason)
+
+    return PullResult(
+        total=len(targets),
+        ok=ok_count,
+        failed=failed,
+        log_file=log_file,
+        elapsed=elapsed,
+    )

--- a/library/src/iqb/scripting/iqb_cache_pull.py
+++ b/library/src/iqb/scripting/iqb_cache_pull.py
@@ -29,7 +29,6 @@ from ..ghremote import DiffState, Manifest, diff, load_manifest, manifest_path_f
 from ..ghremote.diff import DiffEntry
 from ..ghremote.entrypath import ManifestEntryPath
 from ..pipeline.cache import data_dir_or_default
-from .iqb_logging import log
 
 _thread_local = threading.local()
 
@@ -153,7 +152,6 @@ def run(
             targets.append(entry)
 
     if not targets:
-        log.info("nothing to download")
         return None
 
     failed: list[tuple[str, str]] = []
@@ -193,10 +191,6 @@ def run(
             fp.write(json.dumps(span) + "\n")
 
     ok_count = len(targets) - len(failed)
-    log.info("downloaded %d/%d file(s) in %.1fs", ok_count, len(targets), elapsed)
-    if failed:
-        for file, reason in failed:
-            log.warning("failed: %s: %s", file, reason)
 
     return PullResult(
         total=len(targets),

--- a/library/tests/iqb/cli/cache_pull_test.py
+++ b/library/tests/iqb/cli/cache_pull_test.py
@@ -82,7 +82,7 @@ class TestCachePullEmptyManifest:
 class TestCachePullInvalidManifestKeys:
     """Invalid manifest keys are rejected at load time."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_traversal_key_is_rejected(self, mock_session_cls: MagicMock, tmp_path: Path):
         _write_manifest(
             tmp_path,
@@ -104,7 +104,7 @@ class TestCachePullInvalidManifestKeys:
 class TestCachePullOnlyRemote:
     """ONLY_REMOTE entries are downloaded."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_downloads_only_remote(self, mock_session_cls: MagicMock, tmp_path: Path):
         content = b"remote file content"
         sha = _sha256(content)
@@ -140,7 +140,7 @@ class TestCachePullOnlyRemote:
 class TestCachePullMatchingSkipped:
     """MATCHING entries are not downloaded."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_skips_matching(self, mock_session_cls: MagicMock, tmp_path: Path):
         content = b"same content"
         sha = _sha256(content)
@@ -160,7 +160,7 @@ class TestCachePullMatchingSkipped:
 class TestCachePullMismatchSkippedByDefault:
     """SHA256_MISMATCH entries are skipped without --force."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_skips_mismatch(self, mock_session_cls: MagicMock, tmp_path: Path):
         remote_content = b"remote version"
         local_content = b"local version"
@@ -186,7 +186,7 @@ class TestCachePullMismatchSkippedByDefault:
 class TestCachePullMismatchWithForce:
     """SHA256_MISMATCH entries are downloaded with --force."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_downloads_with_force(self, mock_session_cls: MagicMock, tmp_path: Path):
         remote_content = b"remote version"
         local_content = b"local version"
@@ -211,7 +211,7 @@ class TestCachePullMismatchWithForce:
 class TestCachePullSha256Failure:
     """SHA256 verification failure results in exit code 1."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_sha256_failure(self, mock_session_cls: MagicMock, tmp_path: Path):
         expected_content = b"expected content"
         actual_content = b"corrupted content"
@@ -245,7 +245,7 @@ class TestCachePullSha256Failure:
 class TestCachePullMultipleFiles:
     """Multiple ONLY_REMOTE entries are all downloaded."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_downloads_multiple(self, mock_session_cls: MagicMock, tmp_path: Path):
         content_a = b"content a"
         content_b = b"content b"
@@ -288,7 +288,7 @@ class TestCachePullJobsFlag:
 class TestCachePullAtomicWrite:
     """If download fails, no partial file is left on disk."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_no_partial_file_on_failure(self, mock_session_cls: MagicMock, tmp_path: Path):
         content = b"some content"
         _write_manifest(
@@ -331,7 +331,7 @@ class TestCachePullMetrics:
         "error",
     }
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_two_files_produce_two_spans(self, mock_session_cls: MagicMock, tmp_path: Path):
         content_a = b"content a"
         content_b = b"content b"
@@ -421,7 +421,7 @@ def _multi_manifest(
 class TestCachePullFilterDataset:
     """--dataset filters by dataset name."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_single_dataset(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()
@@ -432,7 +432,7 @@ class TestCachePullFilterDataset:
         assert not (tmp_path / _FILE_C).exists()
         assert not (tmp_path / _FILE_D).exists()
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_multiple_datasets(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()
@@ -459,7 +459,7 @@ class TestCachePullFilterDataset:
 class TestCachePullFilterFile:
     """--file filters by filename."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_stats_only(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()
@@ -474,7 +474,7 @@ class TestCachePullFilterFile:
 class TestCachePullFilterAfterBefore:
     """--after and --before filter by start timestamp."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_after_filters_old(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()
@@ -485,7 +485,7 @@ class TestCachePullFilterAfterBefore:
         assert (tmp_path / _FILE_C).exists()
         assert not (tmp_path / _FILE_D).exists()
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_before_filters_new(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()
@@ -498,7 +498,7 @@ class TestCachePullFilterAfterBefore:
         assert not (tmp_path / _FILE_B).exists()
         assert not (tmp_path / _FILE_C).exists()
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_after_and_before_range(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()
@@ -519,7 +519,7 @@ class TestCachePullFilterAfterBefore:
         assert (tmp_path / _FILE_D).exists()
         assert not (tmp_path / _FILE_A).exists()
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_no_matches_shows_nothing(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()
@@ -531,7 +531,7 @@ class TestCachePullFilterAfterBefore:
 class TestCachePullFilterCombined:
     """Filters compose: --dataset + --file + --after/--before."""
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_dataset_and_file(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()
@@ -554,7 +554,7 @@ class TestCachePullFilterCombined:
         assert not (tmp_path / _FILE_B).exists()
         assert not (tmp_path / _FILE_C).exists()
 
-    @patch("iqb.cli.cache_pull.requests.Session")
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_dataset_and_after(self, mock_session_cls: MagicMock, tmp_path: Path):
         _multi_manifest(tmp_path, mock_session_cls)
         runner = CliRunner()

--- a/library/tests/iqb/scripting/iqb_cache_pull_test.py
+++ b/library/tests/iqb/scripting/iqb_cache_pull_test.py
@@ -83,6 +83,7 @@ class TestRunWithProvidedManifest:
         mock_session.get.return_value = _fake_response(content)
         mock_session_cls.return_value = mock_session
 
+        # No manifest on disk — uses provided manifest directly
         result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest)
 
         assert result is not None
@@ -90,21 +91,6 @@ class TestRunWithProvidedManifest:
         assert result.ok == 1
         assert result.failed == []
         assert (tmp_path / _FILE_A).read_bytes() == content
-
-    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
-    def test_no_disk_manifest_needed(self, mock_session_cls: MagicMock, tmp_path: Path):
-        content = b"data"
-        sha = _sha256(content)
-        manifest = _make_manifest({_FILE_A: {"sha256": sha, "url": "https://example.com/a"}})
-
-        mock_session = MagicMock()
-        mock_session.get.return_value = _fake_response(content)
-        mock_session_cls.return_value = mock_session
-
-        # No manifest on disk — should not raise
-        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest)
-        assert result is not None
-        assert result.ok == 1
 
 
 class TestRunFiltering:

--- a/library/tests/iqb/scripting/iqb_cache_pull_test.py
+++ b/library/tests/iqb/scripting/iqb_cache_pull_test.py
@@ -1,0 +1,248 @@
+"""Tests for the iqb.scripting.iqb_cache_pull module."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from iqb.ghremote.cache import FileEntry, Manifest, load_manifest_from_dict
+from iqb.ghremote.entrypath import parse_entry_path
+from iqb.scripting import iqb_cache_pull
+
+_TS1 = "20241001T000000Z"
+_TS2 = "20241101T000000Z"
+_TS3 = "20230601T000000Z"
+_TS4 = "20230701T000000Z"
+_FILE_A = f"cache/v1/{_TS1}/{_TS2}/downloads/data.parquet"
+_FILE_B = f"cache/v1/{_TS1}/{_TS2}/uploads/data.parquet"
+_FILE_C = f"cache/v1/{_TS1}/{_TS2}/downloads/stats.json"
+_FILE_D = f"cache/v1/{_TS3}/{_TS4}/downloads/data.parquet"
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _write_manifest(data_dir: Path, files: dict[str, dict[str, str]]) -> None:
+    manifest_path = data_dir / "state" / "ghremote" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps({"v": 0, "files": files}))
+
+
+def _make_manifest(files: dict[str, dict[str, str]]) -> Manifest:
+    return load_manifest_from_dict({"v": 0, "files": files})
+
+
+def _fake_response(content: bytes) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.headers = {"Content-Length": str(len(content))}
+    resp.iter_content = MagicMock(return_value=iter([content]))
+    return resp
+
+
+class TestRunNothingToDownload:
+    """Returns None when there is nothing to download."""
+
+    def test_empty_manifest_from_disk(self, tmp_path: Path):
+        _write_manifest(tmp_path, {})
+        result = iqb_cache_pull.run(data_dir=tmp_path)
+        assert result is None
+
+    def test_empty_provided_manifest(self, tmp_path: Path):
+        manifest = Manifest(v=0, files={})
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest)
+        assert result is None
+
+    def test_all_matching(self, tmp_path: Path):
+        content = b"matching"
+        sha = _sha256(content)
+        _write_manifest(tmp_path, {_FILE_A: {"sha256": sha, "url": "https://example.com/a"}})
+        dest = tmp_path / _FILE_A
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(content)
+
+        result = iqb_cache_pull.run(data_dir=tmp_path)
+        assert result is None
+
+
+class TestRunWithProvidedManifest:
+    """Accepts a pre-loaded manifest instead of reading from disk."""
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_uses_provided_manifest(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content = b"remote content"
+        sha = _sha256(content)
+        manifest = _make_manifest({_FILE_A: {"sha256": sha, "url": "https://example.com/a"}})
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(content)
+        mock_session_cls.return_value = mock_session
+
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest)
+
+        assert result is not None
+        assert result.total == 1
+        assert result.ok == 1
+        assert result.failed == []
+        assert (tmp_path / _FILE_A).read_bytes() == content
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_no_disk_manifest_needed(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content = b"data"
+        sha = _sha256(content)
+        manifest = _make_manifest({_FILE_A: {"sha256": sha, "url": "https://example.com/a"}})
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(content)
+        mock_session_cls.return_value = mock_session
+
+        # No manifest on disk — should not raise
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest)
+        assert result is not None
+        assert result.ok == 1
+
+
+class TestRunFiltering:
+    """Manifest filtering works with provided manifest."""
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_filter_by_dataset(self, mock_session_cls: MagicMock, tmp_path: Path):
+        ca, cb = b"content_a", b"content_b"
+        manifest = _make_manifest({
+            _FILE_A: {"sha256": _sha256(ca), "url": "https://example.com/a"},
+            _FILE_B: {"sha256": _sha256(cb), "url": "https://example.com/b"},
+        })
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(cb)
+        mock_session_cls.return_value = mock_session
+
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest, datasets=("uploads",))
+
+        assert result is not None
+        assert result.total == 1
+        assert (tmp_path / _FILE_B).exists()
+        assert not (tmp_path / _FILE_A).exists()
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_filter_by_after(self, mock_session_cls: MagicMock, tmp_path: Path):
+        ca, cd = b"content_a", b"content_d"
+        manifest = _make_manifest({
+            _FILE_A: {"sha256": _sha256(ca), "url": "https://example.com/a"},
+            _FILE_D: {"sha256": _sha256(cd), "url": "https://example.com/d"},
+        })
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(ca)
+        mock_session_cls.return_value = mock_session
+
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest, after="2024-01-01")
+
+        assert result is not None
+        assert result.total == 1
+        assert (tmp_path / _FILE_A).exists()
+        assert not (tmp_path / _FILE_D).exists()
+
+
+class TestRunResult:
+    """PullResult is populated correctly."""
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_result_fields(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content = b"data"
+        sha = _sha256(content)
+        manifest = _make_manifest({_FILE_A: {"sha256": sha, "url": "https://example.com/a"}})
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(content)
+        mock_session_cls.return_value = mock_session
+
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest)
+
+        assert result is not None
+        assert result.total == 1
+        assert result.ok == 1
+        assert result.failed == []
+        assert result.log_file.exists()
+        assert result.elapsed >= 0
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_failure_recorded(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content = b"data"
+        manifest = _make_manifest({
+            _FILE_A: {"sha256": _sha256(b"different"), "url": "https://example.com/a"}
+        })
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(content)
+        mock_session_cls.return_value = mock_session
+
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest)
+
+        assert result is not None
+        assert result.total == 1
+        assert result.ok == 0
+        assert len(result.failed) == 1
+        assert "SHA256 mismatch" in result.failed[0][1]
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_metrics_log_written(self, mock_session_cls: MagicMock, tmp_path: Path):
+        content = b"data"
+        sha = _sha256(content)
+        manifest = _make_manifest({_FILE_A: {"sha256": sha, "url": "https://example.com/a"}})
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(content)
+        mock_session_cls.return_value = mock_session
+
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest)
+
+        assert result is not None
+        spans = [json.loads(line) for line in result.log_file.read_text().splitlines() if line]
+        assert len(spans) == 1
+        assert spans[0]["ok"] is True
+        assert spans[0]["file"] == _FILE_A
+
+
+class TestRunForce:
+    """The force flag re-downloads mismatched files."""
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_mismatch_skipped_without_force(self, mock_session_cls: MagicMock, tmp_path: Path):
+        remote = b"remote"
+        local = b"local"
+        manifest = _make_manifest({
+            _FILE_A: {"sha256": _sha256(remote), "url": "https://example.com/a"}
+        })
+        dest = tmp_path / _FILE_A
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(local)
+
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest, force=False)
+        assert result is None
+        assert dest.read_bytes() == local
+
+    @patch("iqb.scripting.iqb_cache_pull.requests.Session")
+    def test_mismatch_downloaded_with_force(self, mock_session_cls: MagicMock, tmp_path: Path):
+        remote = b"remote"
+        local = b"local"
+        manifest = _make_manifest({
+            _FILE_A: {"sha256": _sha256(remote), "url": "https://example.com/a"}
+        })
+        dest = tmp_path / _FILE_A
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(local)
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = _fake_response(remote)
+        mock_session_cls.return_value = mock_session
+
+        result = iqb_cache_pull.run(data_dir=tmp_path, manifest=manifest, force=True)
+        assert result is not None
+        assert result.ok == 1
+        assert dest.read_bytes() == remote

--- a/library/tests/iqb/scripting/iqb_cache_pull_test.py
+++ b/library/tests/iqb/scripting/iqb_cache_pull_test.py
@@ -7,10 +7,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-from iqb.ghremote.cache import FileEntry, Manifest, load_manifest_from_dict
-from iqb.ghremote.entrypath import parse_entry_path
+from iqb.ghremote.cache import Manifest, load_manifest_from_dict
 from iqb.scripting import iqb_cache_pull
 
 _TS1 = "20241001T000000Z"
@@ -99,10 +96,12 @@ class TestRunFiltering:
     @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_filter_by_dataset(self, mock_session_cls: MagicMock, tmp_path: Path):
         ca, cb = b"content_a", b"content_b"
-        manifest = _make_manifest({
-            _FILE_A: {"sha256": _sha256(ca), "url": "https://example.com/a"},
-            _FILE_B: {"sha256": _sha256(cb), "url": "https://example.com/b"},
-        })
+        manifest = _make_manifest(
+            {
+                _FILE_A: {"sha256": _sha256(ca), "url": "https://example.com/a"},
+                _FILE_B: {"sha256": _sha256(cb), "url": "https://example.com/b"},
+            }
+        )
 
         mock_session = MagicMock()
         mock_session.get.return_value = _fake_response(cb)
@@ -118,10 +117,12 @@ class TestRunFiltering:
     @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_filter_by_after(self, mock_session_cls: MagicMock, tmp_path: Path):
         ca, cd = b"content_a", b"content_d"
-        manifest = _make_manifest({
-            _FILE_A: {"sha256": _sha256(ca), "url": "https://example.com/a"},
-            _FILE_D: {"sha256": _sha256(cd), "url": "https://example.com/d"},
-        })
+        manifest = _make_manifest(
+            {
+                _FILE_A: {"sha256": _sha256(ca), "url": "https://example.com/a"},
+                _FILE_D: {"sha256": _sha256(cd), "url": "https://example.com/d"},
+            }
+        )
 
         mock_session = MagicMock()
         mock_session.get.return_value = _fake_response(ca)
@@ -160,9 +161,9 @@ class TestRunResult:
     @patch("iqb.scripting.iqb_cache_pull.requests.Session")
     def test_failure_recorded(self, mock_session_cls: MagicMock, tmp_path: Path):
         content = b"data"
-        manifest = _make_manifest({
-            _FILE_A: {"sha256": _sha256(b"different"), "url": "https://example.com/a"}
-        })
+        manifest = _make_manifest(
+            {_FILE_A: {"sha256": _sha256(b"different"), "url": "https://example.com/a"}}
+        )
 
         mock_session = MagicMock()
         mock_session.get.return_value = _fake_response(content)
@@ -202,9 +203,9 @@ class TestRunForce:
     def test_mismatch_skipped_without_force(self, mock_session_cls: MagicMock, tmp_path: Path):
         remote = b"remote"
         local = b"local"
-        manifest = _make_manifest({
-            _FILE_A: {"sha256": _sha256(remote), "url": "https://example.com/a"}
-        })
+        manifest = _make_manifest(
+            {_FILE_A: {"sha256": _sha256(remote), "url": "https://example.com/a"}}
+        )
         dest = tmp_path / _FILE_A
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(local)
@@ -217,9 +218,9 @@ class TestRunForce:
     def test_mismatch_downloaded_with_force(self, mock_session_cls: MagicMock, tmp_path: Path):
         remote = b"remote"
         local = b"local"
-        manifest = _make_manifest({
-            _FILE_A: {"sha256": _sha256(remote), "url": "https://example.com/a"}
-        })
+        manifest = _make_manifest(
+            {_FILE_A: {"sha256": _sha256(remote), "url": "https://example.com/a"}}
+        )
         dest = tmp_path / _FILE_A
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(local)


### PR DESCRIPTION
This diff refactors the code in iqb/cli/cache_pull.py to split the cache pulling functionality and its CLI.

The machinery now lives inside iqb/scripting mirroring what we already do for the pipeline.

In turn, this means that someone in a notebook can programmatically and efficiently prime the cache as opposed to downloading files on demand.

Closes https://github.com/m-lab/iqb/issues/193