### PR TITLE
feat(iqb/cache): allow merging download and upload

### DIFF
--- a/library/src/iqb/cache/mlab.py
+++ b/library/src/iqb/cache/mlab.py
@@ -126,11 +126,7 @@ class MLabDataFramePair:
         Returns:
             A merged pandas DataFrame.
         """
-        on = [
-            c
-            for c in self.download.columns
-            if c in self.upload.columns and c != "sample_count"
-        ]
+        on = [c for c in self.download.columns if c in self.upload.columns and c != "sample_count"]
         return self.download.merge(self.upload, on=on, suffixes=("_down", "_up"))
 
 

--- a/library/src/iqb/cache/mlab.py
+++ b/library/src/iqb/cache/mlab.py
@@ -116,6 +116,23 @@ class MLabDataFramePair:
             loss=float(download_row[loss_col]),
         )
 
+    def to_merged_data_frame(self) -> pd.DataFrame:
+        """Merge download and upload DataFrames into a single DataFrame.
+
+        Joins on all columns common to both DataFrames (geographic identifiers)
+        except ``sample_count``, which appears in both and is suffixed as
+        ``sample_count_down`` and ``sample_count_up``.
+
+        Returns:
+            A merged pandas DataFrame.
+        """
+        on = [
+            c
+            for c in self.download.columns
+            if c in self.upload.columns and c != "sample_count"
+        ]
+        return self.download.merge(self.upload, on=on, suffixes=("_down", "_up"))
+
 
 @dataclass(frozen=True, kw_only=True)
 class MLabCacheEntry:
@@ -246,7 +263,7 @@ class MLabCacheEntry:
     def read_data_frame_pair(
         self,
         *,
-        country_code: str,
+        country_code: str | None = None,
         city: str | None = None,
         asn: int | None = None,
         subdivision1: str | None = None,
@@ -259,7 +276,7 @@ class MLabCacheEntry:
         loaded, allowing for flexible extraction later.
 
         Arguments:
-            country_code: ISO 2-letter country code (e.g., "US", "DE")
+            country_code: either None (all rows) or ISO 2-letter country code (e.g., "US")
             city: Optional city name (required for "country_city" and "country_city_asn" granularity)
             asn: Optional ASN number (required for "country_city_asn" granularity)
             subdivision1: either None or the desired subdivision1 (e.g., "Massachusetts")
@@ -274,9 +291,9 @@ class MLabCacheEntry:
 
         Example:
             >>> entry = cache.get_cache_entry("2024-10-01", "2024-11-01", "country")
-            >>> pair = entry.get_data_frame_pair(country_code="US")
-            >>> data_p95 = pair.to_dict(percentile=95)
-            >>> data_p50 = pair.to_dict(percentile=50)
+            >>> pair = entry.read_data_frame_pair(country_code="US")
+            >>> data_p95 = pair.to_iqb_data(percentile=95)
+            >>> data_p50 = pair.to_iqb_data(percentile=50)
         """
         # 1. Read download data with filtering (all columns for flexibility)
         download_df = self.read_download_data_frame(

--- a/library/tests/iqb/cache/mlab_test.py
+++ b/library/tests/iqb/cache/mlab_test.py
@@ -397,9 +397,7 @@ class TestToMergedDataFrame:
         download = pd.DataFrame(
             {"country_code": ["US"], "sample_count": [100], "download_p95": [500]}
         )
-        upload = pd.DataFrame(
-            {"country_code": ["US"], "sample_count": [80], "upload_p95": [200]}
-        )
+        upload = pd.DataFrame({"country_code": ["US"], "sample_count": [80], "upload_p95": [200]})
         pair = MLabDataFramePair(download=download, upload=upload)
 
         merged = pair.to_merged_data_frame()

--- a/library/tests/iqb/cache/mlab_test.py
+++ b/library/tests/iqb/cache/mlab_test.py
@@ -164,6 +164,20 @@ class TestMLabCacheManagerIntegration:
         assert "upload_p95" in pair.upload.columns
         assert "upload_p50" in pair.upload.columns
 
+    def test_read_data_frame_pair_unfiltered(self, real_data_dir):
+        manager = _create_manager(real_data_dir)
+        entry = _get_country_cache_entry_2024_10(manager)
+
+        pair = entry.read_data_frame_pair()
+
+        assert len(pair.download) == 236
+        assert len(pair.upload) == 237
+
+        assert "country_code" in pair.download.columns
+        assert "download_p95" in pair.download.columns
+        assert "country_code" in pair.upload.columns
+        assert "upload_p95" in pair.upload.columns
+
     def test_read_data_frame_pair_with_subdivision1(self, fake_data_dir):
         manager = _create_manager(fake_data_dir)
         entry = _get_country_city_cache_entry_2024_10(manager)
@@ -357,3 +371,80 @@ class TestMLabDataFramePairExceptions:
         # percentile=95 will be missing
         with pytest.raises(ValueError, match="Percentile column 'download_p95'"):
             pair.to_iqb_data(percentile=95).to_dict()
+
+
+class TestToMergedDataFrame:
+    def test_joins_on_geographic_columns(self):
+        download = pd.DataFrame(
+            {"country_code": ["US", "DE"], "sample_count": [100, 200], "download_p95": [500, 300]}
+        )
+        upload = pd.DataFrame(
+            {"country_code": ["US", "DE"], "sample_count": [80, 150], "upload_p95": [200, 100]}
+        )
+        pair = MLabDataFramePair(download=download, upload=upload)
+
+        merged = pair.to_merged_data_frame()
+
+        assert len(merged) == 2
+        assert "country_code" in merged.columns
+        assert "download_p95" in merged.columns
+        assert "upload_p95" in merged.columns
+        assert "sample_count_down" in merged.columns
+        assert "sample_count_up" in merged.columns
+        assert "sample_count" not in merged.columns
+
+    def test_sample_count_values(self):
+        download = pd.DataFrame(
+            {"country_code": ["US"], "sample_count": [100], "download_p95": [500]}
+        )
+        upload = pd.DataFrame(
+            {"country_code": ["US"], "sample_count": [80], "upload_p95": [200]}
+        )
+        pair = MLabDataFramePair(download=download, upload=upload)
+
+        merged = pair.to_merged_data_frame()
+
+        assert merged.iloc[0]["sample_count_down"] == 100
+        assert merged.iloc[0]["sample_count_up"] == 80
+
+    def test_city_granularity_join_columns(self):
+        download = pd.DataFrame(
+            {
+                "country_code": ["US", "US"],
+                "subdivision1_iso_code": ["CA", "NY"],
+                "city": ["LA", "NYC"],
+                "sample_count": [10, 20],
+                "download_p95": [500, 400],
+            }
+        )
+        upload = pd.DataFrame(
+            {
+                "country_code": ["US", "US"],
+                "subdivision1_iso_code": ["CA", "NY"],
+                "city": ["LA", "NYC"],
+                "sample_count": [8, 15],
+                "upload_p95": [200, 150],
+            }
+        )
+        pair = MLabDataFramePair(download=download, upload=upload)
+
+        merged = pair.to_merged_data_frame()
+
+        assert len(merged) == 2
+        assert merged.iloc[0]["city"] == "LA"
+        assert merged.iloc[0]["download_p95"] == 500
+        assert merged.iloc[0]["upload_p95"] == 200
+
+    def test_with_real_data(self, real_data_dir):
+        manager = _create_manager(real_data_dir)
+        entry = _get_country_cache_entry_2024_10(manager)
+
+        pair = entry.read_data_frame_pair()
+        merged = pair.to_merged_data_frame()
+
+        assert "download_p95" in merged.columns
+        assert "upload_p95" in merged.columns
+        assert "sample_count_down" in merged.columns
+        assert "sample_count_up" in merged.columns
+        assert "sample_count" not in merged.columns
+        assert len(merged) > 0

--- a/prototype/pages/IQB_Map.py
+++ b/prototype/pages/IQB_Map.py
@@ -39,15 +39,6 @@ MANIFEST_URL = (
     "https://raw.githubusercontent.com/m-lab/iqb/main/data/state/ghremote/manifest.json"
 )
 PERCENTILES = ["p1", "p5", "p10", "p25", "p50", "p75", "p90", "p95", "p99"]
-JOIN_COLS = [
-    "country_code",
-    "subdivision1_iso_code",
-    "city",
-    "period_start",
-    "period_end",
-    "period_label",
-]
-
 # Country coordinates: (lat, lon, zoom)
 COUNTRY_COORDS = {
     "USA": (39.8, -98.5, 3.0),
@@ -299,10 +290,9 @@ def fetch_map_data(_cache: IQBCache, start_date: str, end_date: str) -> dict[str
         end_date=end_date,
         granularity=IQBDatasetGranularity.COUNTRY,
     )
-    download_df = entry.mlab.read_download_data_frame()
-    upload_df = entry.mlab.read_upload_data_frame()
-    merged = download_df.merge(upload_df, on="country_code", suffixes=("", "_up"))
-    percentiles = extract_percentiles_from_columns(download_df.columns)
+    pair = entry.mlab.read_data_frame_pair()
+    merged = pair.to_merged_data_frame()
+    percentiles = extract_percentiles_from_columns(merged.columns)
 
     results = {}
     for _, row in merged.iterrows():
@@ -320,8 +310,8 @@ def fetch_map_data(_cache: IQBCache, start_date: str, end_date: str) -> dict[str
             "name": country_info["name"],
             "metrics": metrics,
             "sample_counts": {
-                "downloads": int(row.get("sample_count", 0)),
-                "uploads": int(row.get("sample_count_up", row.get("sample_count", 0))),
+                "downloads": int(row.get("sample_count_down", 0)),
+                "uploads": int(row.get("sample_count_up", 0)),
             },
         }
     return results
@@ -337,17 +327,12 @@ def fetch_subdivision_data(
         end_date=end_date,
         granularity=IQBDatasetGranularity.COUNTRY_CITY,
     )
-    download_df = entry.mlab.read_download_data_frame(country_code=country_code)
-    upload_df = entry.mlab.read_upload_data_frame(country_code=country_code)
-
-    if download_df.empty or upload_df.empty:
+    pair = entry.mlab.read_data_frame_pair(country_code=country_code)
+    if pair.download.empty or pair.upload.empty:
         return {}
 
-    merge_cols = [
-        c for c in JOIN_COLS if c in download_df.columns and c in upload_df.columns
-    ]
-    merged = download_df.merge(upload_df, on=merge_cols, suffixes=("", "_up"))
-    percentiles = extract_percentiles_from_columns(download_df.columns)
+    merged = pair.to_merged_data_frame()
+    percentiles = extract_percentiles_from_columns(merged.columns)
 
     subdivision_data = {}
     for subdivision_code, group in merged.groupby("subdivision1_iso_code"):
@@ -359,8 +344,8 @@ def fetch_subdivision_data(
             if "-" not in str(subdivision_code)
             else subdivision_code
         )
-        total_samples = group["sample_count"].sum()
-        total_samples_up = group.get("sample_count_up", group["sample_count"]).sum()
+        total_samples = group["sample_count_down"].sum()
+        total_samples_up = group["sample_count_up"].sum()
 
         metrics = {
             "download_throughput_mbps": {},
@@ -372,24 +357,21 @@ def fetch_subdivision_data(
             pkey = f"p{p}"
             if total_samples > 0:
                 metrics["download_throughput_mbps"][pkey] = float(
-                    (group[f"download_p{p}"] * group["sample_count"]).sum()
+                    (group[f"download_p{p}"] * group["sample_count_down"]).sum()
                     / total_samples
                 )
                 metrics["latency_ms"][pkey] = float(
-                    (group[f"latency_p{p}"] * group["sample_count"]).sum()
+                    (group[f"latency_p{p}"] * group["sample_count_down"]).sum()
                     / total_samples
                 )
                 metrics["packet_loss"][pkey] = float(
-                    (group[f"loss_p{p}"] * group["sample_count"]).sum() / total_samples
+                    (group[f"loss_p{p}"] * group["sample_count_down"]).sum()
+                    / total_samples
                 )
             if total_samples_up > 0:
-                sample_col = (
-                    "sample_count_up"
-                    if "sample_count_up" in group.columns
-                    else "sample_count"
-                )
                 metrics["upload_throughput_mbps"][pkey] = float(
-                    (group[f"upload_p{p}"] * group[sample_col]).sum() / total_samples_up
+                    (group[f"upload_p{p}"] * group["sample_count_up"]).sum()
+                    / total_samples_up
                 )
 
         subdivision_data[full_code] = {
@@ -417,17 +399,12 @@ def fetch_city_data(
         end_date=end_date,
         granularity=IQBDatasetGranularity.COUNTRY_CITY,
     )
-    download_df = entry.mlab.read_download_data_frame(country_code=country_code)
-    upload_df = entry.mlab.read_upload_data_frame(country_code=country_code)
-
-    if download_df.empty or upload_df.empty:
+    pair = entry.mlab.read_data_frame_pair(country_code=country_code)
+    if pair.download.empty or pair.upload.empty:
         return {}
 
-    merge_cols = [
-        c for c in JOIN_COLS if c in download_df.columns and c in upload_df.columns
-    ]
-    merged = download_df.merge(upload_df, on=merge_cols, suffixes=("", "_up"))
-    percentiles = extract_percentiles_from_columns(download_df.columns)
+    merged = pair.to_merged_data_frame()
+    percentiles = extract_percentiles_from_columns(merged.columns)
 
     results = {}
     for _, row in merged.iterrows():
@@ -441,8 +418,8 @@ def fetch_city_data(
             "subdivision": subdivision,
             "metrics": metrics,
             "sample_counts": {
-                "downloads": int(row.get("sample_count", 0)),
-                "uploads": int(row.get("sample_count_up", row.get("sample_count", 0))),
+                "downloads": int(row.get("sample_count_down", 0)),
+                "uploads": int(row.get("sample_count_up", 0)),
             },
         }
     return results


### PR DESCRIPTION
This diff modifies iqb/cache/mlab.py to allow merging the download and upload data frames into a single data frame containing both. This change allows us to simplify the current implementation of the prototype.

Closes https://github.com/m-lab/iqb/issues/196