### PR TITLE
feat(calculator): dataclasses for config

### DIFF
--- a/library/src/iqb/__init__.py
+++ b/library/src/iqb/__init__.py
@@ -9,7 +9,16 @@ from importlib.metadata import PackageNotFoundError, version
 from .cache import IQBCache
 from .cache.cache import IQBData
 from .cache.mlab import IQBDataMLab
-from .calculator import IQB_CONFIG, IQBCalculator
+from .calculator import (
+    IQB_CONFIG,
+    IQB_DEFAULT_CONFIG,
+    IQBCalculator,
+    IQBConfig,
+    IQBConfigDataset,
+    IQBConfigNetworkRequirement,
+    IQBConfigUseCase,
+    iqb_config_from_legacy,
+)
 from .ghremote import IQBGitHubRemoteCache, IQBRemoteCache
 from .pipeline import (
     IQBDatasetGranularity,
@@ -30,14 +39,20 @@ __all__ = [
     "IQB",
     "IQBCalculator",
     "IQBCache",
+    "IQBConfig",
+    "IQBConfigDataset",
+    "IQBConfigNetworkRequirement",
+    "IQBConfigUseCase",
     "IQBData",
     "IQBDataMLab",
     "IQB_CONFIG",
+    "IQB_DEFAULT_CONFIG",
     "IQBGitHubRemoteCache",
     "IQBRemoteCache",
     "IQBPipeline",
     "IQBDatasetGranularity",
     "IQBDatasetMLabTable",
+    "iqb_config_from_legacy",
     "iqb_dataset_name_for_mlab",
     "__version__",
 ]

--- a/library/src/iqb/calculator/__init__.py
+++ b/library/src/iqb/calculator/__init__.py
@@ -1,6 +1,23 @@
 """Package implementing IQB score calculation."""
 
 from .calculator import IQBCalculator
-from .config import IQB_CONFIG
+from .config import (
+    IQB_CONFIG,
+    IQB_DEFAULT_CONFIG,
+    IQBConfig,
+    IQBConfigDataset,
+    IQBConfigNetworkRequirement,
+    IQBConfigUseCase,
+    iqb_config_from_legacy,
+)
 
-__all__ = ["IQB_CONFIG", "IQBCalculator"]
+__all__ = [
+    "IQB_CONFIG",
+    "IQB_DEFAULT_CONFIG",
+    "IQBCalculator",
+    "IQBConfig",
+    "IQBConfigDataset",
+    "IQBConfigNetworkRequirement",
+    "IQBConfigUseCase",
+    "iqb_config_from_legacy",
+]

--- a/library/src/iqb/calculator/config.py
+++ b/library/src/iqb/calculator/config.py
@@ -1,4 +1,66 @@
-"""Module containing the default IQB configuration."""
+"""Module containing the IQB configuration dataclasses and defaults."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class IQBConfigDataset:
+    """Configuration for a single dataset within a network requirement."""
+
+    weight: float
+
+
+@dataclass(frozen=True, kw_only=True)
+class IQBConfigNetworkRequirement:
+    """Configuration for a single network requirement within a use case."""
+
+    weight: float
+    threshold_min: float
+    datasets: dict[str, IQBConfigDataset]
+
+
+@dataclass(frozen=True, kw_only=True)
+class IQBConfigUseCase:
+    """Configuration for a single use case."""
+
+    weight: float
+    network_requirements: dict[str, IQBConfigNetworkRequirement]
+
+
+@dataclass(frozen=True, kw_only=True)
+class IQBConfig:
+    """Top-level IQB configuration containing all use cases."""
+
+    use_cases: dict[str, IQBConfigUseCase]
+
+
+def iqb_config_from_legacy(legacy: dict) -> IQBConfig:
+    """Load an IQBConfig from the legacy nested-dict format.
+
+    The legacy format uses keys like ``"use cases"``, ``"network requirements"``,
+    and ``"threshold min"`` with spaces. This function maps them to the
+    corresponding dataclass fields.
+    """
+    use_cases: dict[str, IQBConfigUseCase] = {}
+    for uc_name, uc_dict in legacy["use cases"].items():
+        network_requirements: dict[str, IQBConfigNetworkRequirement] = {}
+        for nr_name, nr_dict in uc_dict["network requirements"].items():
+            datasets: dict[str, IQBConfigDataset] = {}
+            for ds_name, ds_dict in nr_dict["datasets"].items():
+                datasets[ds_name] = IQBConfigDataset(weight=ds_dict["w"])
+            network_requirements[nr_name] = IQBConfigNetworkRequirement(
+                weight=nr_dict["w"],
+                threshold_min=nr_dict["threshold min"],
+                datasets=datasets,
+            )
+        use_cases[uc_name] = IQBConfigUseCase(
+            weight=uc_dict["w"],
+            network_requirements=network_requirements,
+        )
+    return IQBConfig(use_cases=use_cases)
+
 
 IQB_CONFIG = {
     "use cases": {
@@ -248,5 +310,7 @@ IQB_CONFIG = {
                 },
             },
         },
-    }
+    },
 }
+
+IQB_DEFAULT_CONFIG: IQBConfig = iqb_config_from_legacy(IQB_CONFIG)

--- a/library/tests/iqb/cache/cache_test.py
+++ b/library/tests/iqb/cache/cache_test.py
@@ -38,10 +38,11 @@ class TestIQBCacheGetData:
     def test_get_data_us_october_2024(self, real_data_dir):
         """Test fetching US data for October 2024."""
         cache = IQBCache(data_dir=real_data_dir)
-        data = cache.get_data(
-            country="US",
-            start_date=datetime(2024, 10, 1),
-        )
+        with pytest.deprecated_call():
+            data = cache.get_data(
+                country="US",
+                start_date=datetime(2024, 10, 1),
+            )
 
         # Unwrap the `m-lab` part
         assert "m-lab" in data
@@ -62,10 +63,11 @@ class TestIQBCacheGetData:
     def test_get_data_de_october_2024(self, real_data_dir):
         """Test fetching Germany data for October 2024."""
         cache = IQBCache(data_dir=real_data_dir)
-        data = cache.get_data(
-            country="DE",
-            start_date=datetime(2024, 10, 1),
-        )
+        with pytest.deprecated_call():
+            data = cache.get_data(
+                country="DE",
+                start_date=datetime(2024, 10, 1),
+            )
 
         # Unwrap the `m-lab` part
         assert "m-lab" in data
@@ -77,10 +79,11 @@ class TestIQBCacheGetData:
     def test_get_data_br_october_2024(self, real_data_dir):
         """Test fetching Brazil data for October 2024."""
         cache = IQBCache(data_dir=real_data_dir)
-        data = cache.get_data(
-            country="BR",
-            start_date=datetime(2024, 10, 1),
-        )
+        with pytest.deprecated_call():
+            data = cache.get_data(
+                country="BR",
+                start_date=datetime(2024, 10, 1),
+            )
 
         # Unwrap the `m-lab` part
         assert "m-lab" in data
@@ -93,8 +96,10 @@ class TestIQBCacheGetData:
         """Test that country code is case-insensitive."""
         cache = IQBCache(data_dir=real_data_dir)
 
-        data_upper = cache.get_data(country="US", start_date=datetime(2024, 10, 1))
-        data_lower = cache.get_data(country="us", start_date=datetime(2024, 10, 1))
+        with pytest.deprecated_call():
+            data_upper = cache.get_data(country="US", start_date=datetime(2024, 10, 1))
+        with pytest.deprecated_call():
+            data_lower = cache.get_data(country="us", start_date=datetime(2024, 10, 1))
 
         # Should return same data regardless of case
         assert data_upper == data_lower
@@ -103,8 +108,14 @@ class TestIQBCacheGetData:
         """Test extracting different percentile values."""
         cache = IQBCache(data_dir=real_data_dir)
 
-        data_p95 = cache.get_data(country="US", start_date=datetime(2024, 10, 1), percentile=95)
-        data_p50 = cache.get_data(country="US", start_date=datetime(2024, 10, 1), percentile=50)
+        with pytest.deprecated_call():
+            data_p95 = cache.get_data(
+                country="US", start_date=datetime(2024, 10, 1), percentile=95
+            )
+        with pytest.deprecated_call():
+            data_p50 = cache.get_data(
+                country="US", start_date=datetime(2024, 10, 1), percentile=50
+            )
 
         # Unwrap the `m-lab` part
         assert "m-lab" in data_p95
@@ -123,10 +134,11 @@ class TestIQBCacheGetData:
     def test_get_data_france_october_2024(self, real_data_dir):
         """Test fetching France data for October 2024."""
         cache = IQBCache(data_dir=real_data_dir)
-        data = cache.get_data(
-            country="FR",
-            start_date=datetime(2024, 10, 1),
-        )
+        with pytest.deprecated_call():
+            data = cache.get_data(
+                country="FR",
+                start_date=datetime(2024, 10, 1),
+            )
 
         # Unwrap the `m-lab` part
         assert "m-lab" in data
@@ -138,10 +150,11 @@ class TestIQBCacheGetData:
     def test_get_data_canada_october_2024(self, real_data_dir):
         """Test fetching Canada data for October 2024."""
         cache = IQBCache(data_dir=real_data_dir)
-        data = cache.get_data(
-            country="CA",
-            start_date=datetime(2024, 10, 1),
-        )
+        with pytest.deprecated_call():
+            data = cache.get_data(
+                country="CA",
+                start_date=datetime(2024, 10, 1),
+            )
 
         # Unwrap the `m-lab` part
         assert "m-lab" in data
@@ -155,7 +168,7 @@ class TestIQBCacheGetData:
         cache = IQBCache(data_dir=real_data_dir)
 
         # Use a fictional country code that won't exist
-        with pytest.raises(
+        with pytest.deprecated_call(), pytest.raises(
             ValueError,
             match="Expected exactly 1 row in download DataFrame, but got 0 rows",
         ):
@@ -165,7 +178,9 @@ class TestIQBCacheGetData:
         """Test that requesting data for unavailable date raises FileNotFoundError."""
         cache = IQBCache(data_dir=real_data_dir)
 
-        with pytest.raises(FileNotFoundError, match=r"Cache entry not found"):
+        with pytest.deprecated_call(), pytest.raises(
+            FileNotFoundError, match=r"Cache entry not found"
+        ):
             cache.get_data(country="US", start_date=datetime(2024, 11, 1))
 
 

--- a/library/tests/iqb/cache/cache_test.py
+++ b/library/tests/iqb/cache/cache_test.py
@@ -109,13 +109,9 @@ class TestIQBCacheGetData:
         cache = IQBCache(data_dir=real_data_dir)
 
         with pytest.deprecated_call():
-            data_p95 = cache.get_data(
-                country="US", start_date=datetime(2024, 10, 1), percentile=95
-            )
+            data_p95 = cache.get_data(country="US", start_date=datetime(2024, 10, 1), percentile=95)
         with pytest.deprecated_call():
-            data_p50 = cache.get_data(
-                country="US", start_date=datetime(2024, 10, 1), percentile=50
-            )
+            data_p50 = cache.get_data(country="US", start_date=datetime(2024, 10, 1), percentile=50)
 
         # Unwrap the `m-lab` part
         assert "m-lab" in data_p95
@@ -168,9 +164,12 @@ class TestIQBCacheGetData:
         cache = IQBCache(data_dir=real_data_dir)
 
         # Use a fictional country code that won't exist
-        with pytest.deprecated_call(), pytest.raises(
-            ValueError,
-            match="Expected exactly 1 row in download DataFrame, but got 0 rows",
+        with (
+            pytest.deprecated_call(),
+            pytest.raises(
+                ValueError,
+                match="Expected exactly 1 row in download DataFrame, but got 0 rows",
+            ),
         ):
             cache.get_data(country="ZZ", start_date=datetime(2024, 10, 1))
 
@@ -178,8 +177,9 @@ class TestIQBCacheGetData:
         """Test that requesting data for unavailable date raises FileNotFoundError."""
         cache = IQBCache(data_dir=real_data_dir)
 
-        with pytest.deprecated_call(), pytest.raises(
-            FileNotFoundError, match=r"Cache entry not found"
+        with (
+            pytest.deprecated_call(),
+            pytest.raises(FileNotFoundError, match=r"Cache entry not found"),
         ):
             cache.get_data(country="US", start_date=datetime(2024, 11, 1))
 

--- a/library/tests/iqb/calculator/config_test.py
+++ b/library/tests/iqb/calculator/config_test.py
@@ -83,7 +83,7 @@ class TestIQBDefaultConfigIsDerivedFromLegacy:
     def test_default_equals_from_legacy(self):
         """IQB_DEFAULT_CONFIG equals a fresh conversion of IQB_CONFIG."""
         fresh = iqb_config_from_legacy(IQB_CONFIG)
-        assert IQB_DEFAULT_CONFIG == fresh
+        assert fresh == IQB_DEFAULT_CONFIG
 
     def test_idempotent_conversion(self):
         """Converting IQB_CONFIG twice yields equal results."""

--- a/library/tests/iqb/calculator/config_test.py
+++ b/library/tests/iqb/calculator/config_test.py
@@ -1,0 +1,196 @@
+"""Tests for the IQB configuration dataclasses and legacy loading."""
+
+import pytest
+
+from iqb import (
+    IQB_CONFIG,
+    IQB_DEFAULT_CONFIG,
+    IQBConfig,
+    IQBConfigDataset,
+    IQBConfigNetworkRequirement,
+    IQBConfigUseCase,
+    iqb_config_from_legacy,
+)
+
+
+class TestIQBConfigFromLegacyPreservesAllData:
+    """Verify that iqb_config_from_legacy does not lose any information."""
+
+    def test_all_use_cases_present(self):
+        """Every use case in the legacy dict appears in the dataclass."""
+        legacy_ucs = set(IQB_CONFIG["use cases"].keys())
+        config_ucs = set(IQB_DEFAULT_CONFIG.use_cases.keys())
+        assert config_ucs == legacy_ucs
+
+    def test_all_network_requirements_present(self):
+        """Every network requirement in each legacy use case appears in the dataclass."""
+        for uc_name, uc_dict in IQB_CONFIG["use cases"].items():
+            legacy_nrs = set(uc_dict["network requirements"].keys())
+            config_nrs = set(IQB_DEFAULT_CONFIG.use_cases[uc_name].network_requirements.keys())
+            assert config_nrs == legacy_nrs, f"mismatch in use case {uc_name!r}"
+
+    def test_all_datasets_present(self):
+        """Every dataset in each legacy network requirement appears in the dataclass."""
+        for uc_name, uc_dict in IQB_CONFIG["use cases"].items():
+            for nr_name, nr_dict in uc_dict["network requirements"].items():
+                legacy_ds = set(nr_dict["datasets"].keys())
+                config_ds = set(
+                    IQB_DEFAULT_CONFIG.use_cases[uc_name]
+                    .network_requirements[nr_name]
+                    .datasets.keys()
+                )
+                assert config_ds == legacy_ds, f"mismatch in {uc_name!r}/{nr_name!r}"
+
+    def test_use_case_weights_match(self):
+        """Use case weights match the legacy dict values."""
+        for uc_name, uc_dict in IQB_CONFIG["use cases"].items():
+            assert IQB_DEFAULT_CONFIG.use_cases[uc_name].weight == uc_dict["w"]
+
+    def test_network_requirement_weights_match(self):
+        """Network requirement weights match the legacy dict values."""
+        for uc_name, uc_dict in IQB_CONFIG["use cases"].items():
+            for nr_name, nr_dict in uc_dict["network requirements"].items():
+                nr = IQB_DEFAULT_CONFIG.use_cases[uc_name].network_requirements[nr_name]
+                assert nr.weight == nr_dict["w"], f"weight mismatch in {uc_name!r}/{nr_name!r}"
+
+    def test_network_requirement_thresholds_match(self):
+        """Network requirement threshold_min values match the legacy dict values."""
+        for uc_name, uc_dict in IQB_CONFIG["use cases"].items():
+            for nr_name, nr_dict in uc_dict["network requirements"].items():
+                nr = IQB_DEFAULT_CONFIG.use_cases[uc_name].network_requirements[nr_name]
+                assert nr.threshold_min == nr_dict["threshold min"], (
+                    f"threshold mismatch in {uc_name!r}/{nr_name!r}"
+                )
+
+    def test_dataset_weights_match(self):
+        """Dataset weights match the legacy dict values."""
+        for uc_name, uc_dict in IQB_CONFIG["use cases"].items():
+            for nr_name, nr_dict in uc_dict["network requirements"].items():
+                for ds_name, ds_dict in nr_dict["datasets"].items():
+                    ds = (
+                        IQB_DEFAULT_CONFIG.use_cases[uc_name]
+                        .network_requirements[nr_name]
+                        .datasets[ds_name]
+                    )
+                    assert ds.weight == ds_dict["w"], (
+                        f"weight mismatch in {uc_name!r}/{nr_name!r}/{ds_name!r}"
+                    )
+
+
+class TestIQBDefaultConfigIsDerivedFromLegacy:
+    """Verify that IQB_DEFAULT_CONFIG is the same object as iqb_config_from_legacy(IQB_CONFIG)."""
+
+    def test_default_equals_from_legacy(self):
+        """IQB_DEFAULT_CONFIG equals a fresh conversion of IQB_CONFIG."""
+        fresh = iqb_config_from_legacy(IQB_CONFIG)
+        assert IQB_DEFAULT_CONFIG == fresh
+
+    def test_idempotent_conversion(self):
+        """Converting IQB_CONFIG twice yields equal results."""
+        first = iqb_config_from_legacy(IQB_CONFIG)
+        second = iqb_config_from_legacy(IQB_CONFIG)
+        assert first == second
+
+
+class TestIQBConfigDataclasses:
+    """Tests for the dataclass types themselves."""
+
+    def test_iqb_config_is_frozen(self):
+        """IQBConfig instances are immutable."""
+        with pytest.raises(AttributeError):
+            IQB_DEFAULT_CONFIG.use_cases = {}  # type: ignore[misc]
+
+    def test_iqb_config_use_case_is_frozen(self):
+        """IQBConfigUseCase instances are immutable."""
+        uc = next(iter(IQB_DEFAULT_CONFIG.use_cases.values()))
+        with pytest.raises(AttributeError):
+            uc.weight = 99  # type: ignore[misc]
+
+    def test_iqb_config_network_requirement_is_frozen(self):
+        """IQBConfigNetworkRequirement instances are immutable."""
+        uc = next(iter(IQB_DEFAULT_CONFIG.use_cases.values()))
+        nr = next(iter(uc.network_requirements.values()))
+        with pytest.raises(AttributeError):
+            nr.weight = 99  # type: ignore[misc]
+
+    def test_iqb_config_dataset_is_frozen(self):
+        """IQBConfigDataset instances are immutable."""
+        uc = next(iter(IQB_DEFAULT_CONFIG.use_cases.values()))
+        nr = next(iter(uc.network_requirements.values()))
+        ds = next(iter(nr.datasets.values()))
+        with pytest.raises(AttributeError):
+            ds.weight = 99  # type: ignore[misc]
+
+    def test_construct_programmatically(self):
+        """Verify that configs can be built manually without the legacy loader."""
+        config = IQBConfig(
+            use_cases={
+                "test": IQBConfigUseCase(
+                    weight=1.0,
+                    network_requirements={
+                        "download_throughput_mbps": IQBConfigNetworkRequirement(
+                            weight=3.0,
+                            threshold_min=10.0,
+                            datasets={"m-lab": IQBConfigDataset(weight=1.0)},
+                        ),
+                    },
+                ),
+            },
+        )
+        assert config.use_cases["test"].weight == 1.0
+        nr = config.use_cases["test"].network_requirements["download_throughput_mbps"]
+        assert nr.weight == 3.0
+        assert nr.threshold_min == 10.0
+        assert nr.datasets["m-lab"].weight == 1.0
+
+
+class TestIQBConfigFromLegacyErrors:
+    """Tests for error handling in iqb_config_from_legacy."""
+
+    def test_missing_use_cases_key(self):
+        """Raises KeyError when 'use cases' key is missing."""
+        with pytest.raises(KeyError):
+            iqb_config_from_legacy({})
+
+    def test_missing_network_requirements_key(self):
+        """Raises KeyError when 'network requirements' key is missing."""
+        with pytest.raises(KeyError):
+            iqb_config_from_legacy({"use cases": {"test": {"w": 1}}})
+
+    def test_missing_threshold_min_key(self):
+        """Raises KeyError when 'threshold min' key is missing."""
+        with pytest.raises(KeyError):
+            iqb_config_from_legacy(
+                {
+                    "use cases": {
+                        "test": {
+                            "w": 1,
+                            "network requirements": {
+                                "download_throughput_mbps": {
+                                    "w": 3,
+                                    "datasets": {"m-lab": {"w": 1}},
+                                }
+                            },
+                        }
+                    }
+                }
+            )
+
+    def test_missing_datasets_key(self):
+        """Raises KeyError when 'datasets' key is missing."""
+        with pytest.raises(KeyError):
+            iqb_config_from_legacy(
+                {
+                    "use cases": {
+                        "test": {
+                            "w": 1,
+                            "network requirements": {
+                                "download_throughput_mbps": {
+                                    "w": 3,
+                                    "threshold min": 10,
+                                }
+                            },
+                        }
+                    }
+                }
+            )

--- a/library/tests/iqb/cli/cache_pull_test.py
+++ b/library/tests/iqb/cli/cache_pull_test.py
@@ -68,6 +68,13 @@ def _fake_response(content: bytes) -> MagicMock:
     return resp
 
 
+class TestFindLogFile:
+    """Tests for the _find_log_file helper."""
+
+    def test_returns_none_when_log_dir_missing(self, tmp_path: Path):
+        assert _find_log_file(tmp_path) is None
+
+
 class TestCachePullEmptyManifest:
     """Empty manifest produces 'Nothing to download.'."""
 

--- a/library/tests/iqb/integration_test.py
+++ b/library/tests/iqb/integration_test.py
@@ -15,8 +15,9 @@ class TestIntegration:
         # Instantiate the cache with the global cache dir
         cache = IQBCache(data_dir=real_data_dir)
 
-        # Read the data from the cache
-        data = cache.get_data("US", start_date=datetime.strptime("2024-10-01", "%Y-%m-%d"))
+        # Read the data from the cache (deprecated API)
+        with pytest.deprecated_call():
+            data = cache.get_data("US", start_date=datetime.strptime("2024-10-01", "%Y-%m-%d"))
 
         # Create the calculator
         calculator = IQBCalculator()


### PR DESCRIPTION
While preserving backward compatibility, this diff introduces proper dataclasses for representing the IQB config.

This change, in turn, paves the way for more structurally sound and type checked code in the calculator itself.

Authoring this code is out of scope of this PR, though.

While there, silence warnings for code using deprecated APIs when running tests, and make sure we assert we are invoking deprecated APIs via `pytest`.

While there, add missing cache_pull_test.py test to ensure there is full code coverage in the library.