### PR TITLE
refactor(IQBCalculator)!: use config dataclass

### DIFF
--- a/library/src/iqb/calculator/calculator.py
+++ b/library/src/iqb/calculator/calculator.py
@@ -1,68 +1,43 @@
 """Module that implements calculating IQB scores."""
 
-from pprint import pprint
+import dataclasses
+import json
 
 from ..cache.cache import IQBData
-from .config import IQB_CONFIG
+from .config import IQB_DEFAULT_CONFIG, IQBConfig, iqb_config_from_legacy
 
 
 class IQBCalculator:
     """Component that calculates IQB scores."""
 
-    def __init__(self, config=None, name=None):
+    def __init__(self, config: IQBConfig | dict | str | None = None, name=None):
         """
         Initialize a new instance of IQBCalculator.
 
         Parameters:
-            config (str): The file with the configuration of the IQB formula parameters. If "None" (default), it gets the parameters from the IQB_CONFIG dict.
+            config: IQBConfig dataclass, legacy dict, file path, or None for default config.
             name (str): [Optional] name for the IQBCalculator instance.
         """
         self.set_config(config)
         self.name = name
 
-    def set_config(self, config):
-        """Sets up configuration parameters. If "None" (default), it gets the parameters from the IQB_CONFIG dict."""
+    def set_config(self, config: IQBConfig | dict | str | None):
+        """Sets up configuration parameters. If None, uses the default config."""
         if config is None:
-            self.config = IQB_CONFIG
-            # TODO: check the format of the config is the same of the IQB_CONFIG
-        elif isinstance(config, dict):
+            self.config = IQB_DEFAULT_CONFIG
+        elif isinstance(config, IQBConfig):
             self.config = config
+        elif isinstance(config, dict):
+            self.config = iqb_config_from_legacy(config)
         else:
-            # TODO: load config data from file (json, yaml, or other format) as a dict
+            # TODO(bassosimone): implement loading config from file (json, yaml)
             raise NotImplementedError(
                 "method for reading from configuration file other than the default not implemented"
             )
 
     def print_config(self):
-        """
-        Prints IQB formula weights and thresholds
-        TEMP function for testing purposes.
-        """
-        # TODO: to be updated
-        print("### IQB formula weights and thresholds")
-        pprint(IQB_CONFIG)
-        print()
-
-        print("### Use cases")
-        for uc in IQB_CONFIG["use cases"]:
-            print(f"\t{uc}")
-        print()
-
-        print("### Network requirements")
-        for uc in IQB_CONFIG["use cases"]:
-            for nr in IQB_CONFIG["use cases"][uc]["network requirements"]:
-                print(f"\t{nr}")
-            break
-        print()
-
-        print("### Weights & Thresholds")
-        print("\tUse case\t \tNetwork requirement \tWeight \tThreshold min")
-        for uc in IQB_CONFIG["use cases"]:
-            for nr in IQB_CONFIG["use cases"][uc]["network requirements"]:
-                nr_w = IQB_CONFIG["use cases"][uc]["network requirements"][nr]["w"]
-                nr_th = IQB_CONFIG["use cases"][uc]["network requirements"][nr]["threshold min"]
-                print(f"\t{uc:20} \t{nr:20} \t{nr_w} \t{nr_th}")
-        print()
+        """Prints the current IQB configuration as JSON."""
+        print(json.dumps(dataclasses.asdict(self.config), indent=2))
 
     def calculate_binary_requirement_score(self, network_requirement, value, threshold):
         """
@@ -96,42 +71,39 @@ class IQBCalculator:
         uc_scores = []
         uc_weights = []
 
-        for uc in self.config["use cases"]:
-            uc_w = self.config["use cases"][uc]["w"]
-
+        for uc_name, uc_cfg in self.config.use_cases.items():
             nr_scores = []
             nr_weights = []
-            for nr in self.config["use cases"][uc]["network requirements"]:
-                nr_w = self.config["use cases"][uc]["network requirements"][nr]["w"]
-                nr_th = self.config["use cases"][uc]["network requirements"][nr]["threshold min"]
-
+            for nr_name, nr_cfg in uc_cfg.network_requirements.items():
                 # TODO: TEMP method for calculating binary requirement scores. To be
                 # updated with weighted average of scores per dataset.
                 ds_s = []
-                for ds in self.config["use cases"][uc]["network requirements"][nr]["datasets"]:
-                    if ds not in data:
+                for ds_name, ds_cfg in nr_cfg.datasets.items():
+                    if ds_name not in data:
                         continue
-                    ds_w = self.config["use cases"][uc]["network requirements"][nr]["datasets"][ds][
-                        "w"
-                    ]
-                    if ds_w > 0:
+                    if ds_cfg.weight > 0:
                         # binary requirement score (dataset, network requirement)
-                        brs = self.calculate_binary_requirement_score(nr, data[ds][nr], nr_th)
+                        brs = self.calculate_binary_requirement_score(
+                            nr_name, data[ds_name][nr_name], nr_cfg.threshold_min
+                        )
                         ds_s.append(brs)
-                        doprint(f"Binary score: {uc},{nr},{ds},{nr_th},{data[ds][nr]}-->{brs}")
+                        doprint(
+                            f"Binary score: {uc_name},{nr_name},{ds_name},"
+                            f"{nr_cfg.threshold_min},{data[ds_name][nr_name]}-->{brs}"
+                        )
 
                 # requirement agreement score (all datasets for this requirement)
                 ras = sum(ds_s) / len(ds_s)
-                doprint(f"\t Agreement score: {uc},{nr}-->{ras}")
+                doprint(f"\t Agreement score: {uc_name},{nr_name}-->{ras}")
 
-                nr_scores.append(ras * nr_w)
-                nr_weights.append(nr_w)
+                nr_scores.append(ras * nr_cfg.weight)
+                nr_weights.append(nr_cfg.weight)
 
             # use case score (all requirements for this use case)
             ucs = sum(nr_scores) / sum(nr_weights)
             doprint(f"\t\t Net requirement score: {nr_scores},{nr_weights}-->{ucs}\n")
-            uc_scores.append(ucs * uc_w)
-            uc_weights.append(uc_w)
+            uc_scores.append(ucs * uc_cfg.weight)
+            uc_weights.append(uc_cfg.weight)
 
         iqb_score = sum(uc_scores) / sum(uc_weights)
         doprint(f"\t\t\t IQB score: {uc_scores},{uc_weights}-->{iqb_score}")

--- a/library/tests/iqb/calculator/calculator_test.py
+++ b/library/tests/iqb/calculator/calculator_test.py
@@ -1,8 +1,10 @@
 """Tests for the IQBCalculator score calculation module."""
 
+import json
+
 import pytest
 
-from iqb import IQB_CONFIG, IQBCalculator, IQBData, IQBDataMLab
+from iqb import IQB_CONFIG, IQB_DEFAULT_CONFIG, IQBCalculator, IQBData, IQBDataMLab
 
 
 class TestIQBCalculatorInitialization:
@@ -21,12 +23,12 @@ class TestIQBCalculatorInitialization:
     def test_init_uses_default_config(self):
         """Test that IQBCalculator uses default config when none provided."""
         iqb = IQBCalculator()
-        assert iqb.config == IQB_CONFIG
+        assert iqb.config == IQB_DEFAULT_CONFIG
 
     def test_init_with_dict_config(self):
-        """Test that IQBCalculator accepts a dict config."""
+        """Test that IQBCalculator converts a dict config to IQBConfig."""
         iqb = IQBCalculator(config=IQB_CONFIG)
-        assert iqb.config is IQB_CONFIG
+        assert iqb.config == IQB_DEFAULT_CONFIG
 
     def test_init_with_invalid_config_raises_error(self):
         """Test that providing a non-existent config file raises NotImplementedError."""
@@ -378,50 +380,69 @@ class TestIQBCalculatorConfig:
     def test_config_has_use_cases(self):
         """Test that config contains use cases."""
         iqb = IQBCalculator()
-        assert "use cases" in iqb.config
-        assert len(iqb.config["use cases"]) > 0
+        assert len(iqb.config.use_cases) > 0
 
     def test_config_use_cases_have_network_requirements(self):
         """Test that each use case has network requirements."""
         iqb = IQBCalculator()
-        for use_case in iqb.config["use cases"].values():
-            assert "network requirements" in use_case
-            assert len(use_case["network requirements"]) > 0
+        for use_case in iqb.config.use_cases.values():
+            assert len(use_case.network_requirements) > 0
 
     def test_config_network_requirements_have_weights(self):
         """Test that each network requirement has weights."""
         iqb = IQBCalculator()
-        for use_case in iqb.config["use cases"].values():
-            for nr in use_case["network requirements"].values():
-                assert "w" in nr
-                assert isinstance(nr["w"], (int, float))
+        for use_case in iqb.config.use_cases.values():
+            for nr in use_case.network_requirements.values():
+                assert isinstance(nr.weight, (int, float))
 
     def test_config_network_requirements_have_thresholds(self):
         """Test that each network requirement has thresholds."""
         iqb = IQBCalculator()
-        for use_case in iqb.config["use cases"].values():
-            for nr in use_case["network requirements"].values():
-                assert "threshold min" in nr
+        for use_case in iqb.config.use_cases.values():
+            for nr in use_case.network_requirements.values():
+                assert isinstance(nr.threshold_min, (int, float))
 
 
 class TestIQBCalculatorMethods:
     """Tests for IQBCalculator utility methods."""
 
-    def test_print_config_runs_without_error(self, capsys):
-        """Test that print_config method runs without errors."""
+    def test_print_config_outputs_valid_json(self, capsys):
+        """Test that print_config outputs valid JSON matching the config."""
         iqb = IQBCalculator()
         iqb.print_config()
         captured = capsys.readouterr()
-        assert "### IQB formula weights and thresholds" in captured.out
-        assert "### Use cases" in captured.out
-        assert "### Network requirements" in captured.out
-        assert "### Weights & Thresholds" in captured.out
+        parsed = json.loads(captured.out)
+        assert "use_cases" in parsed
+        assert "web browsing" in parsed["use_cases"]
+        assert "gaming" in parsed["use_cases"]
+
+    def test_print_config_uses_instance_config(self, capsys):
+        """Test that print_config prints the instance's config, not the global."""
+        config = {
+            "use cases": {
+                "test": {
+                    "w": 1,
+                    "network requirements": {
+                        "download_throughput_mbps": {
+                            "w": 1,
+                            "threshold min": 10,
+                            "datasets": {"m-lab": {"w": 1}},
+                        },
+                    },
+                },
+            },
+        }
+        iqb = IQBCalculator(config=config)
+        iqb.print_config()
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert list(parsed["use_cases"].keys()) == ["test"]
 
     def test_set_config_with_none(self):
         """Test that set_config works with None."""
         iqb = IQBCalculator()
         iqb.set_config(None)
-        assert iqb.config == IQB_CONFIG
+        assert iqb.config == IQB_DEFAULT_CONFIG
 
     def test_set_config_with_file_raises_error(self):
         """Test that set_config raises error for file paths."""


### PR DESCRIPTION
This diff upgrades the IQBCalculator codebase to use the IQBConfig dataclass rather than raw dictionaries.

As a side effect, we have now more robustness in the overall algorithm since dataclasses have more structure and are more robust than raw dictionaries.

BREAKING CHANGE: IQBCalculator.config is now an instance of the IQBConfig dataclass rather than a dict.

BREAKING CHANGE: IQBCalculator.print_config now prints the round tripping JSON config rather than text.