### PR TITLE
cleanup(calculator)!: remove print_details

### DIFF
--- a/library/src/iqb/calculator/calculator.py
+++ b/library/src/iqb/calculator/calculator.py
@@ -67,7 +67,7 @@ class IQBCalculator:
         uc_scores = []
         uc_weights = []
 
-        for uc_name, uc_cfg in self.config.use_cases.items():
+        for _uc_name, uc_cfg in self.config.use_cases.items():
             nr_scores = []
             nr_weights = []
             for nr_name, nr_cfg in uc_cfg.network_requirements.items():

--- a/library/src/iqb/calculator/calculator.py
+++ b/library/src/iqb/calculator/calculator.py
@@ -58,15 +58,11 @@ class IQBCalculator:
                 f"The binary requirement score method is not implemented for the network_requirement: {network_requirement}"
             )
 
-    def calculate_iqb_score(self, data: dict | IQBData, print_details=False):
+    def calculate_iqb_score(self, data: dict | IQBData):
         """Calculates IQB score based on given data."""
 
         if isinstance(data, IQBData):
             data = data.to_dict()
-
-        # TODO(bassosimone): remove printing from the current function and instead
-        # add more tests to gain better confidence about it being WAI
-        doprint = print if print_details else lambda *args, **kwargs: None
 
         uc_scores = []
         uc_weights = []
@@ -87,24 +83,17 @@ class IQBCalculator:
                             nr_name, data[ds_name][nr_name], nr_cfg.threshold_min
                         )
                         ds_s.append(brs)
-                        doprint(
-                            f"Binary score: {uc_name},{nr_name},{ds_name},"
-                            f"{nr_cfg.threshold_min},{data[ds_name][nr_name]}-->{brs}"
-                        )
 
                 # requirement agreement score (all datasets for this requirement)
                 ras = sum(ds_s) / len(ds_s)
-                doprint(f"\t Agreement score: {uc_name},{nr_name}-->{ras}")
 
                 nr_scores.append(ras * nr_cfg.weight)
                 nr_weights.append(nr_cfg.weight)
 
             # use case score (all requirements for this use case)
             ucs = sum(nr_scores) / sum(nr_weights)
-            doprint(f"\t\t Net requirement score: {nr_scores},{nr_weights}-->{ucs}\n")
             uc_scores.append(ucs * uc_cfg.weight)
             uc_weights.append(uc_cfg.weight)
 
         iqb_score = sum(uc_scores) / sum(uc_weights)
-        doprint(f"\t\t\t IQB score: {uc_scores},{uc_weights}-->{iqb_score}")
         return iqb_score

--- a/library/tests/iqb/calculator/calculator_test.py
+++ b/library/tests/iqb/calculator/calculator_test.py
@@ -136,12 +136,6 @@ class TestIQBCalculatorScoreCalculation:
         score = iqb.calculate_iqb_score(data=self._SAMPLE_DATA)
         assert score == pytest.approx(4 / 7)
 
-    def test_calculate_iqb_score_print_details(self):
-        """Test that IQBCalculator score calculation works with print_details=True."""
-        iqb = IQBCalculator()
-        score = iqb.calculate_iqb_score(data=self._SAMPLE_DATA, print_details=True)
-        assert score == pytest.approx(4 / 7)
-
     def test_calculate_iqb_score_consistency(self):
         """Test that IQBCalculator score calculation is consistent across calls."""
         iqb = IQBCalculator()

--- a/prototype/Home.py
+++ b/prototype/Home.py
@@ -69,9 +69,7 @@ def main():
     with right_col:
         try:
             data_for_calculation = build_data_for_calculate(state)
-            iqb_score = state.iqb.calculate_iqb_score(
-                data=data_for_calculation, print_details=False
-            )
+            iqb_score = state.iqb.calculate_iqb_score(data=data_for_calculation)
 
             tab1, tab2, tab3 = st.tabs(["Requirements", "Use Cases", "Full Hierarchy"])
 

--- a/prototype/pages/IQB_Map.py
+++ b/prototype/pages/IQB_Map.py
@@ -244,7 +244,7 @@ def calculate_iqb_score_from_metrics(
             percentile
         ]
         iqb_data = build_iqb_data_from_cache(metrics, percentile)
-        return temp_state.iqb.calculate_iqb_score(data=iqb_data, print_details=False)
+        return temp_state.iqb.calculate_iqb_score(data=iqb_data)
     except Exception:
         return None
 
@@ -1579,9 +1579,7 @@ if (
             tab1, tab2, tab3 = st.tabs(["Requirements", "Use Cases", "Full Hierarchy"])
             try:
                 iqb_data = build_iqb_data_from_cache(metrics, percentile)
-                iqb_score = state.iqb.calculate_iqb_score(
-                    data=iqb_data, print_details=False
-                )
+                iqb_score = state.iqb.calculate_iqb_score(data=iqb_data)
                 with tab1:
                     render_sunburst(
                         prepare_requirements_sunburst_data(state),
@@ -1713,9 +1711,7 @@ if (
             tab1, tab2, tab3 = st.tabs(["Requirements", "Use Cases", "Full Hierarchy"])
             try:
                 iqb_data = build_iqb_data_from_cache(metrics, percentile)
-                iqb_score = state.iqb.calculate_iqb_score(
-                    data=iqb_data, print_details=False
-                )
+                iqb_score = state.iqb.calculate_iqb_score(data=iqb_data)
                 with tab1:
                     render_sunburst(
                         prepare_requirements_sunburst_data(state),


### PR DESCRIPTION
Printing the details was already slated for removal via a TODO and now we execute the sentence and remove it from the tree.

BREAKING CHANGE: IQBCalculator.calculate_iqb_score's print_details parameter has been removed.